### PR TITLE
Define source and canonical transaction contracts

### DIFF
--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -1,15 +1,8 @@
-"""Framework-independent domain contracts for Phase 1 recategorization."""
+"""Framework-independent transaction and categorization domain contracts."""
 
 from enum import StrEnum
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    computed_field,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def _require_non_blank(value: str, field_name: str) -> str:
@@ -18,8 +11,16 @@ def _require_non_blank(value: str, field_name: str) -> str:
     return value
 
 
+class DecisionType(StrEnum):
+    """The AI categorization outcomes supported in the initial workflow."""
+
+    AI_SUGGESTION = "ai_suggestion"
+    AI_PROPOSED_NEW_CATEGORY = "ai_proposed_new_category"
+    UNRESOLVED = "unresolved"
+
+
 class TransactionDirection(StrEnum):
-    """The flow of money represented by a transaction."""
+    """The flow of money represented by a canonical transaction."""
 
     DEBIT = "debit"
     CREDIT = "credit"
@@ -27,41 +28,15 @@ class TransactionDirection(StrEnum):
 
 
 class TransactionIdentityQuality(StrEnum):
-    """How reliably the transaction can be identified and matched."""
+    """How reliably a canonical transaction can be identified and matched."""
 
     COMPLETE = "complete"
     PARTIAL = "partial"
     INSUFFICIENT = "insufficient"
 
 
-class DecisionType(StrEnum):
-    """Every categorization path available in Phase 1."""
-
-    EXACT_STATEMENT_MEMORY_MATCH = "exact_statement_memory_match"
-    MERCHANT_CONSENSUS = "merchant_consensus"
-    AI_SUGGESTION_WITH_RELEVANT_MEMORY = "ai_suggestion_with_relevant_memory"
-    AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY = "ai_suggestion_without_relevant_memory"
-    AI_PROPOSED_NEW_CATEGORY = "ai_proposed_new_category"
-    UNRESOLVED = "unresolved"
-
-
-class DecisionConfidence(StrEnum):
-    """The strength of evidence supporting a categorization decision."""
-
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-
-
-class BatchStatus(StrEnum):
-    """The externally observable state of a Phase 1 batch."""
-
-    COMPLETED = "completed"
-    APPROVAL_REQUIRED = "approval_required"
-
-
-class CanonicalTransaction(BaseModel):
-    """A source transaction normalized for categorization within one request."""
+class SourceTransaction(BaseModel):
+    """Transaction values preserved as received from a source."""
 
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
@@ -71,175 +46,79 @@ class CanonicalTransaction(BaseModel):
     statement: str | None = None
     amount: float | None = None
     original_category: str | None = None
+
+    @field_validator("transaction_id")
+    @classmethod
+    def transaction_id_must_not_be_blank(cls, value: str) -> str:
+        return _require_non_blank(value, "transaction_id")
+
+
+class ManualCategorization(BaseModel):
+    """A category explicitly selected by a user and therefore trusted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: str
+    note: str | None = None
+
+    @field_validator("category")
+    @classmethod
+    def category_must_not_be_blank(cls, value: str) -> str:
+        return _require_non_blank(value, "category")
+
+
+class CategorizationDecision(BaseModel):
+    """The details and evidence of one AI categorization outcome."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    decision_id: str
+    decision_type: DecisionType
+    suggested_category: str | None = None
+    proposed_category: str | None = None
+    reason: str
+    supporting_memory_ids: list[str] = Field(default_factory=list)
+
+    @field_validator("decision_id", "reason")
+    @classmethod
+    def required_text_must_not_be_blank(cls, value: str, info) -> str:
+        return _require_non_blank(value, info.field_name)
+
+    @model_validator(mode="after")
+    def suggestion_contains_only_suggested_category(self) -> "CategorizationDecision":
+        if self.decision_type is not DecisionType.AI_SUGGESTION:
+            return self
+        if not self.suggested_category or self.proposed_category:
+            raise ValueError("AI suggestion must contain only suggested_category")
+        return self
+
+    @model_validator(mode="after")
+    def proposal_contains_only_proposed_category(self) -> "CategorizationDecision":
+        if self.decision_type is not DecisionType.AI_PROPOSED_NEW_CATEGORY:
+            return self
+        if not self.proposed_category or self.suggested_category:
+            raise ValueError("AI category proposal must contain only proposed_category")
+        return self
+
+    @model_validator(mode="after")
+    def unresolved_contains_no_category(self) -> "CategorizationDecision":
+        if self.decision_type is not DecisionType.UNRESOLVED:
+            return self
+        if self.suggested_category or self.proposed_category:
+            raise ValueError("unresolved AI decision cannot contain a category")
+        return self
+
+
+class CanonicalTransaction(BaseModel):
+    """A processed transaction with canonical identity and categorization state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: SourceTransaction
     normalized_merchant: str | None = None
     normalized_statement: str | None = None
     direction: TransactionDirection
     identity_quality: TransactionIdentityQuality
     fingerprint: str | None = Field(default=None, min_length=1)
-
-    @field_validator("transaction_id")
-    @classmethod
-    def transaction_id_must_not_be_blank(cls, value: str) -> str:
-        return _require_non_blank(value, "transaction_id")
-
-
-class CategorizationDecision(BaseModel):
-    """The outcome and evidence of categorizing one canonical transaction."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    transaction_id: str
-    decision_type: DecisionType
-    accepted_category: str | None = None
-    suggested_category: str | None = None
-    proposed_category: str | None = None
-    needs_review: bool
-    confidence: DecisionConfidence | None = None
-    reason: str = Field(min_length=1)
-    supporting_memory_ids: list[str] = Field(default_factory=list)
-
-    @field_validator("transaction_id")
-    @classmethod
-    def transaction_id_must_not_be_blank(cls, value: str) -> str:
-        return _require_non_blank(value, "transaction_id")
-
-    @model_validator(mode="after")
-    def deterministic_decision_has_only_accepted_category(self) -> "CategorizationDecision":
-        deterministic_types = {
-            DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
-            DecisionType.MERCHANT_CONSENSUS,
-        }
-        if self.decision_type not in deterministic_types:
-            return self
-        if not self.accepted_category:
-            raise ValueError("deterministic decision requires accepted_category")
-        if self.suggested_category or self.proposed_category:
-            raise ValueError("deterministic decision may only contain accepted_category")
-        if self.needs_review:
-            raise ValueError("deterministic decision must not need review")
-        return self
-
-    @model_validator(mode="after")
-    def ai_decision_has_reviewable_category(self) -> "CategorizationDecision":
-        suggestion_types = {
-            DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
-            DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
-        }
-        ai_types = suggestion_types | {DecisionType.AI_PROPOSED_NEW_CATEGORY}
-        if self.decision_type not in ai_types:
-            return self
-        if not self.needs_review:
-            raise ValueError("every AI decision must need review")
-        if self.accepted_category:
-            raise ValueError("AI decisions cannot contain accepted_category")
-        if self.decision_type in suggestion_types:
-            if not self.suggested_category or self.proposed_category:
-                raise ValueError("AI suggestion must contain only suggested_category")
-        elif not self.proposed_category or self.suggested_category:
-            raise ValueError("AI-proposed category must contain only proposed_category")
-        if (
-            self.decision_type is DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY
-            and not self.supporting_memory_ids
-        ):
-            raise ValueError("AI suggestion with relevant memory requires supporting memory IDs")
-        if (
-            self.decision_type is DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY
-            and self.supporting_memory_ids
-        ):
-            raise ValueError("AI suggestion without relevant memory cannot cite memory IDs")
-        return self
-
-    @model_validator(mode="after")
-    def unresolved_decision_has_no_category(self) -> "CategorizationDecision":
-        if self.decision_type is not DecisionType.UNRESOLVED:
-            return self
-        if self.accepted_category or self.suggested_category or self.proposed_category:
-            raise ValueError("unresolved decision cannot contain a category")
-        if not self.needs_review:
-            raise ValueError("unresolved decision must need review")
-        return self
-
-
-class RecategorizationResult(BaseModel):
-    """A transaction and its decision at the transaction's original position."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    position: int = Field(ge=0)
-    transaction: CanonicalTransaction
-    decision: CategorizationDecision
-
-    @model_validator(mode="after")
-    def transaction_and_decision_ids_match(self) -> "RecategorizationResult":
-        if self.transaction.transaction_id != self.decision.transaction_id:
-            raise ValueError("transaction and decision IDs must match")
-        return self
-
-
-class RecategorizationBatch(BaseModel):
-    """An ordered Phase 1 recategorization response with derived summary counts."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    batch_id: str = Field(min_length=1)
-    status: BatchStatus
-    results: list[RecategorizationResult]
-    openai_request_count: int = Field(ge=0)
-
-    @field_validator("batch_id")
-    @classmethod
-    def batch_id_must_not_be_blank(cls, value: str) -> str:
-        return _require_non_blank(value, "batch_id")
-
-    @model_validator(mode="after")
-    def results_follow_input_order(self) -> "RecategorizationBatch":
-        positions = [result.position for result in self.results]
-        if positions != list(range(len(self.results))):
-            raise ValueError("result positions must preserve zero-based input order")
-        transaction_ids = [result.transaction.transaction_id for result in self.results]
-        if len(transaction_ids) != len(set(transaction_ids)):
-            raise ValueError("transaction IDs must be unique within a batch")
-        return self
-
-    @computed_field
-    @property
-    def total_count(self) -> int:
-        return len(self.results)
-
-    @computed_field
-    @property
-    def deterministic_count(self) -> int:
-        deterministic_types = {
-            DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
-            DecisionType.MERCHANT_CONSENSUS,
-        }
-        return sum(
-            result.decision.decision_type in deterministic_types for result in self.results
-        )
-
-    @computed_field
-    @property
-    def ai_reviewed_count(self) -> int:
-        ai_types = {
-            DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
-            DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
-            DecisionType.AI_PROPOSED_NEW_CATEGORY,
-        }
-        return sum(result.decision.decision_type in ai_types for result in self.results)
-
-    @computed_field
-    @property
-    def unknown_count(self) -> int:
-        return sum(
-            result.decision.decision_type is DecisionType.UNRESOLVED for result in self.results
-        )
-
-    @computed_field
-    @property
-    def needs_review_count(self) -> int:
-        return sum(result.decision.needs_review for result in self.results)
-
-    @computed_field
-    @property
-    def approval_required(self) -> bool:
-        return self.status is BatchStatus.APPROVAL_REQUIRED
+    ai_categorization: CategorizationDecision | None = None
+    manual_categorization: ManualCategorization | None = None

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -1,0 +1,245 @@
+"""Framework-independent domain contracts for Phase 1 recategorization."""
+
+from enum import StrEnum
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+
+def _require_non_blank(value: str, field_name: str) -> str:
+    if not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    return value
+
+
+class TransactionDirection(StrEnum):
+    """The flow of money represented by a transaction."""
+
+    DEBIT = "debit"
+    CREDIT = "credit"
+    UNKNOWN = "unknown"
+
+
+class TransactionIdentityQuality(StrEnum):
+    """How reliably the transaction can be identified and matched."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    INSUFFICIENT = "insufficient"
+
+
+class DecisionType(StrEnum):
+    """Every categorization path available in Phase 1."""
+
+    EXACT_STATEMENT_MEMORY_MATCH = "exact_statement_memory_match"
+    MERCHANT_CONSENSUS = "merchant_consensus"
+    AI_SUGGESTION_WITH_RELEVANT_MEMORY = "ai_suggestion_with_relevant_memory"
+    AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY = "ai_suggestion_without_relevant_memory"
+    AI_PROPOSED_NEW_CATEGORY = "ai_proposed_new_category"
+    UNRESOLVED = "unresolved"
+
+
+class DecisionConfidence(StrEnum):
+    """The strength of evidence supporting a categorization decision."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class BatchStatus(StrEnum):
+    """The externally observable state of a Phase 1 batch."""
+
+    COMPLETED = "completed"
+    APPROVAL_REQUIRED = "approval_required"
+
+
+class CanonicalTransaction(BaseModel):
+    """A source transaction normalized for categorization within one request."""
+
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    transaction_id: str
+    date: str | None = None
+    merchant: str | None = None
+    statement: str | None = None
+    amount: float | None = None
+    original_category: str | None = None
+    normalized_merchant: str | None = None
+    normalized_statement: str | None = None
+    direction: TransactionDirection
+    identity_quality: TransactionIdentityQuality
+    fingerprint: str | None = Field(default=None, min_length=1)
+
+    @field_validator("transaction_id")
+    @classmethod
+    def transaction_id_must_not_be_blank(cls, value: str) -> str:
+        return _require_non_blank(value, "transaction_id")
+
+
+class CategorizationDecision(BaseModel):
+    """The outcome and evidence of categorizing one canonical transaction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transaction_id: str
+    decision_type: DecisionType
+    accepted_category: str | None = None
+    suggested_category: str | None = None
+    proposed_category: str | None = None
+    needs_review: bool
+    confidence: DecisionConfidence | None = None
+    reason: str = Field(min_length=1)
+    supporting_memory_ids: list[str] = Field(default_factory=list)
+
+    @field_validator("transaction_id")
+    @classmethod
+    def transaction_id_must_not_be_blank(cls, value: str) -> str:
+        return _require_non_blank(value, "transaction_id")
+
+    @model_validator(mode="after")
+    def deterministic_decision_has_only_accepted_category(self) -> "CategorizationDecision":
+        deterministic_types = {
+            DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
+            DecisionType.MERCHANT_CONSENSUS,
+        }
+        if self.decision_type not in deterministic_types:
+            return self
+        if not self.accepted_category:
+            raise ValueError("deterministic decision requires accepted_category")
+        if self.suggested_category or self.proposed_category:
+            raise ValueError("deterministic decision may only contain accepted_category")
+        if self.needs_review:
+            raise ValueError("deterministic decision must not need review")
+        return self
+
+    @model_validator(mode="after")
+    def ai_decision_has_reviewable_category(self) -> "CategorizationDecision":
+        suggestion_types = {
+            DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
+            DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
+        }
+        ai_types = suggestion_types | {DecisionType.AI_PROPOSED_NEW_CATEGORY}
+        if self.decision_type not in ai_types:
+            return self
+        if not self.needs_review:
+            raise ValueError("every AI decision must need review")
+        if self.accepted_category:
+            raise ValueError("AI decisions cannot contain accepted_category")
+        if self.decision_type in suggestion_types:
+            if not self.suggested_category or self.proposed_category:
+                raise ValueError("AI suggestion must contain only suggested_category")
+        elif not self.proposed_category or self.suggested_category:
+            raise ValueError("AI-proposed category must contain only proposed_category")
+        if (
+            self.decision_type is DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY
+            and not self.supporting_memory_ids
+        ):
+            raise ValueError("AI suggestion with relevant memory requires supporting memory IDs")
+        if (
+            self.decision_type is DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY
+            and self.supporting_memory_ids
+        ):
+            raise ValueError("AI suggestion without relevant memory cannot cite memory IDs")
+        return self
+
+    @model_validator(mode="after")
+    def unresolved_decision_has_no_category(self) -> "CategorizationDecision":
+        if self.decision_type is not DecisionType.UNRESOLVED:
+            return self
+        if self.accepted_category or self.suggested_category or self.proposed_category:
+            raise ValueError("unresolved decision cannot contain a category")
+        if not self.needs_review:
+            raise ValueError("unresolved decision must need review")
+        return self
+
+
+class RecategorizationResult(BaseModel):
+    """A transaction and its decision at the transaction's original position."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    position: int = Field(ge=0)
+    transaction: CanonicalTransaction
+    decision: CategorizationDecision
+
+    @model_validator(mode="after")
+    def transaction_and_decision_ids_match(self) -> "RecategorizationResult":
+        if self.transaction.transaction_id != self.decision.transaction_id:
+            raise ValueError("transaction and decision IDs must match")
+        return self
+
+
+class RecategorizationBatch(BaseModel):
+    """An ordered Phase 1 recategorization response with derived summary counts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    batch_id: str = Field(min_length=1)
+    status: BatchStatus
+    results: list[RecategorizationResult]
+    openai_request_count: int = Field(ge=0)
+
+    @field_validator("batch_id")
+    @classmethod
+    def batch_id_must_not_be_blank(cls, value: str) -> str:
+        return _require_non_blank(value, "batch_id")
+
+    @model_validator(mode="after")
+    def results_follow_input_order(self) -> "RecategorizationBatch":
+        positions = [result.position for result in self.results]
+        if positions != list(range(len(self.results))):
+            raise ValueError("result positions must preserve zero-based input order")
+        transaction_ids = [result.transaction.transaction_id for result in self.results]
+        if len(transaction_ids) != len(set(transaction_ids)):
+            raise ValueError("transaction IDs must be unique within a batch")
+        return self
+
+    @computed_field
+    @property
+    def total_count(self) -> int:
+        return len(self.results)
+
+    @computed_field
+    @property
+    def deterministic_count(self) -> int:
+        deterministic_types = {
+            DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
+            DecisionType.MERCHANT_CONSENSUS,
+        }
+        return sum(
+            result.decision.decision_type in deterministic_types for result in self.results
+        )
+
+    @computed_field
+    @property
+    def ai_reviewed_count(self) -> int:
+        ai_types = {
+            DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
+            DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
+            DecisionType.AI_PROPOSED_NEW_CATEGORY,
+        }
+        return sum(result.decision.decision_type in ai_types for result in self.results)
+
+    @computed_field
+    @property
+    def unknown_count(self) -> int:
+        return sum(
+            result.decision.decision_type is DecisionType.UNRESOLVED for result in self.results
+        )
+
+    @computed_field
+    @property
+    def needs_review_count(self) -> int:
+        return sum(result.decision.needs_review for result in self.results)
+
+    @computed_field
+    @property
+    def approval_required(self) -> bool:
+        return self.status is BatchStatus.APPROVAL_REQUIRED

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -1,8 +1,16 @@
 """Framework-independent transaction and categorization domain contracts."""
 
+from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 
 def _require_non_blank(value: str, field_name: str) -> str:
@@ -44,7 +52,7 @@ class SourceTransaction(BaseModel):
     date: str | None = None
     merchant: str | None = None
     statement: str | None = None
-    amount: float | None = None
+    amount: Decimal | None = None
     original_category: str | None = None
 
     @field_validator("transaction_id")
@@ -81,30 +89,34 @@ class CategorizationDecision(BaseModel):
 
     @field_validator("decision_id", "reason")
     @classmethod
-    def required_text_must_not_be_blank(cls, value: str, info) -> str:
+    def required_text_must_not_be_blank(cls, value: str, info: ValidationInfo) -> str:
         return _require_non_blank(value, info.field_name)
 
-    @model_validator(mode="after")
-    def suggestion_contains_only_suggested_category(self) -> "CategorizationDecision":
-        if self.decision_type is not DecisionType.AI_SUGGESTION:
-            return self
-        if not self.suggested_category or self.proposed_category:
-            raise ValueError("AI suggestion must contain only suggested_category")
-        return self
+    @field_validator("suggested_category", "proposed_category")
+    @classmethod
+    def category_must_not_be_blank(
+        cls,
+        value: str | None,
+        info: ValidationInfo,
+    ) -> str | None:
+        if value is None:
+            return None
+        return _require_non_blank(value, info.field_name)
+
+    @field_validator("supporting_memory_ids")
+    @classmethod
+    def supporting_memory_ids_must_not_be_blank(cls, values: list[str]) -> list[str]:
+        return [_require_non_blank(value, "supporting_memory_id") for value in values]
 
     @model_validator(mode="after")
-    def proposal_contains_only_proposed_category(self) -> "CategorizationDecision":
-        if self.decision_type is not DecisionType.AI_PROPOSED_NEW_CATEGORY:
-            return self
-        if not self.proposed_category or self.suggested_category:
-            raise ValueError("AI category proposal must contain only proposed_category")
-        return self
-
-    @model_validator(mode="after")
-    def unresolved_contains_no_category(self) -> "CategorizationDecision":
-        if self.decision_type is not DecisionType.UNRESOLVED:
-            return self
-        if self.suggested_category or self.proposed_category:
+    def category_matches_decision_type(self) -> "CategorizationDecision":
+        if self.decision_type is DecisionType.AI_SUGGESTION:
+            if not self.suggested_category or self.proposed_category:
+                raise ValueError("AI suggestion must contain only suggested_category")
+        elif self.decision_type is DecisionType.AI_PROPOSED_NEW_CATEGORY:
+            if not self.proposed_category or self.suggested_category:
+                raise ValueError("AI category proposal must contain only proposed_category")
+        elif self.suggested_category or self.proposed_category:
             raise ValueError("unresolved AI decision cannot contain a category")
         return self
 

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -1,75 +1,89 @@
-# Phase 1 Domain Contracts
+# Transaction Domain Contracts
 
-This reference is for developers implementing Transaction Ingestion,
-Categorization Memory, the OpenAI Reviewer, or the Recategorization Engine. The
-validated models live in `bookkeeping_app/domain_contracts.py` and do not import
-FastAPI upload types or OpenAI SDK response types.
+This reference is for developers implementing transaction ingestion,
+normalization, AI categorization, or manual review. The validated models live in
+`bookkeeping_app/domain_contracts.py` and do not depend on FastAPI or OpenAI SDK
+types.
 
-## Canonical Transaction
+## Lifecycle
 
-`CanonicalTransaction` preserves source data while carrying the normalized
-identity used by categorization.
+```text
+SourceTransaction
+        |
+        | normalization and identity processing
+        v
+CanonicalTransaction
+        |-- ai_categorization: CategorizationDecision | None
+        `-- manual_categorization: ManualCategorization | None
+```
+
+`SourceTransaction` and `CanonicalTransaction` are separate models. If
+processing fails, the source transaction remains available without constructing
+a canonical transaction.
+
+## Source Transaction
+
+`SourceTransaction` preserves transaction-level values received from a source
+before merchant and statement normalization. It is not the raw CSV row or image
+content.
 
 | Field | Meaning |
 | --- | --- |
-| `transaction_id` | Non-blank identifier unique within one request. |
-| `date` | Original transaction date text, if provided. |
-| `merchant` | Original merchant text, if provided. |
-| `statement` | Original statement or description text, if provided. |
-| `amount` | Original numeric amount, if parseable. |
-| `original_category` | Category supplied by the source, if any. |
-| `normalized_merchant` | Merchant identity normalized by ingestion. |
-| `normalized_statement` | Statement identity normalized by ingestion. |
+| `transaction_id` | Non-blank identifier assigned to the source transaction. |
+| `date` | Date value supplied by the source, if present. |
+| `merchant` | Merchant text supplied by the source, if present. |
+| `statement` | Statement or description supplied by the source, if present. |
+| `amount` | Parsed numeric amount, if available. |
+| `original_category` | Category supplied by the source, if present. |
+
+Source values are preserved; normalization belongs to canonical processing.
+
+## Canonical Transaction
+
+`CanonicalTransaction` embeds its `SourceTransaction` and adds processed
+identity plus the latest AI and manual categorization state.
+
+| Field | Meaning |
+| --- | --- |
+| `source` | The source transaction from which this record was produced. |
+| `normalized_merchant` | Merchant identity produced by normalization. |
+| `normalized_statement` | Statement identity produced by normalization. |
 | `direction` | `debit`, `credit`, or `unknown`. |
 | `identity_quality` | `complete`, `partial`, or `insufficient`. |
-| `fingerprint` | Optional stable identity for duplicate detection. |
+| `fingerprint` | Optional stable identity used for duplicate detection. |
+| `ai_categorization` | Optional AI decision details. |
+| `manual_categorization` | Optional trusted category selected by the user. |
 
-Source fields may be absent because incomplete input is a valid domain state.
-Ingestion decides normalization, direction, identity quality, and fingerprinting;
-the contract only validates and transports those results.
+The AI and manual categorizations may coexist. Manual review does not overwrite
+the AI decision, allowing later comparison between the suggestion and the
+category selected by the user.
 
-## Categorization Decision
+## AI Categorization Decision
 
-`CategorizationDecision` associates one transaction ID with exactly one Phase 1
-decision path.
+`CategorizationDecision` records one AI outcome and its explanation. All AI
+decisions require review by domain definition, so the model does not carry a
+redundant `needs_review` flag or an undefined confidence label.
 
-| Decision type | Category field | Review requirement |
-| --- | --- | --- |
-| `exact_statement_memory_match` | `accepted_category` | Must not need review. |
-| `merchant_consensus` | `accepted_category` | Must not need review. |
-| `ai_suggestion_with_relevant_memory` | `suggested_category` | Must need review. |
-| `ai_suggestion_without_relevant_memory` | `suggested_category` | Must need review. |
-| `ai_proposed_new_category` | `proposed_category` | Must need review. |
-| `unresolved` | No category | Must need review. |
+| Decision type | Category fields |
+| --- | --- |
+| `ai_suggestion` | Requires `suggested_category`; forbids `proposed_category`. |
+| `ai_proposed_new_category` | Requires `proposed_category`; forbids `suggested_category`. |
+| `unresolved` | Forbids both category fields. |
 
-Every decision also carries `confidence`, a human-readable `reason`, and the IDs
-of supporting memory items when applicable. Accepted, suggested, and proposed
-categories are separate fields so downstream code cannot silently promote an AI
-result into an accepted category.
+Each decision has a non-blank `decision_id` and `reason`. It may cite
+`supporting_memory_ids` when the AI used categorization memory.
 
-The `with_relevant_memory` path requires at least one supporting memory ID; the
-`without_relevant_memory` path rejects supporting memory IDs. This keeps the two
-AI paths distinguishable from their data, not only from their type names.
+An AI decision never becomes trusted automatically. If the user accepts the AI
+suggestion, the application records the same category in
+`manual_categorization`.
 
-An AI-derived result is never a Trusted Categorization in Phase 1. It becomes
-trusted only after explicit user confirmation, which is outside these contracts.
+## Manual Categorization
 
-## Recategorization Batch
+`ManualCategorization` contains a non-blank category explicitly selected by the
+user and an optional note. Its presence means manual review has occurred; its
+absence means the transaction has not received a manual judgment.
 
-`RecategorizationResult` binds a canonical transaction to its decision and its
-zero-based input position. Their transaction IDs must match.
+## Deferred Contracts
 
-`RecategorizationBatch` contains the ordered results, batch status, and OpenAI
-request count. Result positions must be contiguous and in input order. The model
-derives these response fields from its results:
-
-- `total_count`
-- `deterministic_count`
-- `ai_reviewed_count`
-- `unknown_count`
-- `needs_review_count`
-- `approval_required`
-
-`approval_required` is true when status is `approval_required`; otherwise a
-completed batch uses status `completed`. Computing summary fields prevents a
-caller from constructing a batch whose counts disagree with its decisions.
+Deterministic categorization types, confidence calculation,
+`RecategorizationBatch`, and batch summary counts are intentionally deferred.

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -33,10 +33,12 @@ content.
 | `date` | Date value supplied by the source, if present. |
 | `merchant` | Merchant text supplied by the source, if present. |
 | `statement` | Statement or description supplied by the source, if present. |
-| `amount` | Parsed numeric amount, if available. |
+| `amount` | Exact decimal amount, if available. |
 | `original_category` | Category supplied by the source, if present. |
 
 Source values are preserved; normalization belongs to canonical processing.
+Amounts use `Decimal` so financial values are not rounded through binary
+floating-point conversion.
 
 ## Canonical Transaction
 

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -1,0 +1,75 @@
+# Phase 1 Domain Contracts
+
+This reference is for developers implementing Transaction Ingestion,
+Categorization Memory, the OpenAI Reviewer, or the Recategorization Engine. The
+validated models live in `bookkeeping_app/domain_contracts.py` and do not import
+FastAPI upload types or OpenAI SDK response types.
+
+## Canonical Transaction
+
+`CanonicalTransaction` preserves source data while carrying the normalized
+identity used by categorization.
+
+| Field | Meaning |
+| --- | --- |
+| `transaction_id` | Non-blank identifier unique within one request. |
+| `date` | Original transaction date text, if provided. |
+| `merchant` | Original merchant text, if provided. |
+| `statement` | Original statement or description text, if provided. |
+| `amount` | Original numeric amount, if parseable. |
+| `original_category` | Category supplied by the source, if any. |
+| `normalized_merchant` | Merchant identity normalized by ingestion. |
+| `normalized_statement` | Statement identity normalized by ingestion. |
+| `direction` | `debit`, `credit`, or `unknown`. |
+| `identity_quality` | `complete`, `partial`, or `insufficient`. |
+| `fingerprint` | Optional stable identity for duplicate detection. |
+
+Source fields may be absent because incomplete input is a valid domain state.
+Ingestion decides normalization, direction, identity quality, and fingerprinting;
+the contract only validates and transports those results.
+
+## Categorization Decision
+
+`CategorizationDecision` associates one transaction ID with exactly one Phase 1
+decision path.
+
+| Decision type | Category field | Review requirement |
+| --- | --- | --- |
+| `exact_statement_memory_match` | `accepted_category` | Must not need review. |
+| `merchant_consensus` | `accepted_category` | Must not need review. |
+| `ai_suggestion_with_relevant_memory` | `suggested_category` | Must need review. |
+| `ai_suggestion_without_relevant_memory` | `suggested_category` | Must need review. |
+| `ai_proposed_new_category` | `proposed_category` | Must need review. |
+| `unresolved` | No category | Must need review. |
+
+Every decision also carries `confidence`, a human-readable `reason`, and the IDs
+of supporting memory items when applicable. Accepted, suggested, and proposed
+categories are separate fields so downstream code cannot silently promote an AI
+result into an accepted category.
+
+The `with_relevant_memory` path requires at least one supporting memory ID; the
+`without_relevant_memory` path rejects supporting memory IDs. This keeps the two
+AI paths distinguishable from their data, not only from their type names.
+
+An AI-derived result is never a Trusted Categorization in Phase 1. It becomes
+trusted only after explicit user confirmation, which is outside these contracts.
+
+## Recategorization Batch
+
+`RecategorizationResult` binds a canonical transaction to its decision and its
+zero-based input position. Their transaction IDs must match.
+
+`RecategorizationBatch` contains the ordered results, batch status, and OpenAI
+request count. Result positions must be contiguous and in input order. The model
+derives these response fields from its results:
+
+- `total_count`
+- `deterministic_count`
+- `ai_reviewed_count`
+- `unknown_count`
+- `needs_review_count`
+- `approval_required`
+
+`approval_required` is true when status is `approval_required`; otherwise a
+completed batch uses status `completed`. Computing summary fields prevents a
+caller from constructing a batch whose counts disagree with its decisions.

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -1,0 +1,294 @@
+import pytest
+from pydantic import ValidationError
+
+from bookkeeping_app.domain_contracts import (
+    BatchStatus,
+    CanonicalTransaction,
+    CategorizationDecision,
+    DecisionConfidence,
+    DecisionType,
+    RecategorizationBatch,
+    RecategorizationResult,
+    TransactionDirection,
+    TransactionIdentityQuality,
+)
+
+
+def test_canonical_transaction_preserves_source_and_normalized_identity() -> None:
+    transaction = CanonicalTransaction(
+        transaction_id="txn-1",
+        date="2026-03-24",
+        merchant=" ELECTRIFY AMERICA ",
+        statement="ELECTRIFY AMERICA 65RESTON VA",
+        amount=-7.0,
+        original_category="Gas",
+        normalized_merchant="electrify america",
+        normalized_statement="electrify america 65reston va",
+        direction=TransactionDirection.DEBIT,
+        identity_quality=TransactionIdentityQuality.COMPLETE,
+        fingerprint="sha256:abc123",
+    )
+
+    assert transaction.transaction_id == "txn-1"
+    assert transaction.merchant == " ELECTRIFY AMERICA "
+    assert transaction.normalized_merchant == "electrify america"
+    assert transaction.direction is TransactionDirection.DEBIT
+    assert transaction.identity_quality is TransactionIdentityQuality.COMPLETE
+
+
+def test_domain_contracts_reject_blank_identifiers() -> None:
+    with pytest.raises(ValidationError):
+        CanonicalTransaction(
+            transaction_id=" ",
+            direction=TransactionDirection.UNKNOWN,
+            identity_quality=TransactionIdentityQuality.INSUFFICIENT,
+        )
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            transaction_id=" ",
+            decision_type=DecisionType.UNRESOLVED,
+            needs_review=True,
+            reason="Transaction identity is insufficient.",
+        )
+
+    with pytest.raises(ValidationError):
+        RecategorizationBatch(
+            batch_id=" ",
+            status=BatchStatus.COMPLETED,
+            results=[],
+            openai_request_count=0,
+        )
+
+
+def test_exact_statement_match_contains_only_an_accepted_category() -> None:
+    decision = CategorizationDecision(
+        transaction_id="txn-1",
+        decision_type=DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
+        accepted_category="Electric Vehicle Charging",
+        needs_review=False,
+        confidence=DecisionConfidence.HIGH,
+        reason="Matched a trusted transaction statement.",
+        supporting_memory_ids=["memory-1"],
+    )
+
+    assert decision.accepted_category == "Electric Vehicle Charging"
+    assert decision.suggested_category is None
+    assert decision.proposed_category is None
+    assert decision.needs_review is False
+
+
+@pytest.mark.parametrize(
+    ("decision_type", "category_field"),
+    [
+        (DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY, "suggested_category"),
+        (DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY, "suggested_category"),
+        (DecisionType.AI_PROPOSED_NEW_CATEGORY, "proposed_category"),
+    ],
+)
+def test_every_ai_decision_uses_its_distinct_category_field_and_needs_review(
+    decision_type: DecisionType,
+    category_field: str,
+) -> None:
+    fields = {
+        "transaction_id": "txn-1",
+        "decision_type": decision_type,
+        category_field: "Electric Vehicle Charging",
+        "needs_review": True,
+        "confidence": DecisionConfidence.MEDIUM,
+        "reason": "AI reviewed the available evidence.",
+        "supporting_memory_ids": (
+            ["memory-1"]
+            if decision_type is DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY
+            else []
+        ),
+    }
+
+    decision = CategorizationDecision(**fields)
+
+    assert getattr(decision, category_field) == "Electric Vehicle Charging"
+    assert decision.accepted_category is None
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(**(fields | {"needs_review": False}))
+
+
+def test_ai_memory_context_type_agrees_with_supporting_memory() -> None:
+    common_fields = {
+        "transaction_id": "txn-1",
+        "suggested_category": "Electric Vehicle Charging",
+        "needs_review": True,
+        "reason": "AI reviewed the available evidence.",
+    }
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            decision_type=DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
+            supporting_memory_ids=[],
+            **common_fields,
+        )
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            decision_type=DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
+            supporting_memory_ids=["memory-1"],
+            **common_fields,
+        )
+
+
+def test_merchant_consensus_contains_only_an_accepted_category() -> None:
+    fields = {
+        "transaction_id": "txn-2",
+        "decision_type": DecisionType.MERCHANT_CONSENSUS,
+        "accepted_category": "Restaurants",
+        "needs_review": False,
+        "confidence": DecisionConfidence.HIGH,
+        "reason": "Trusted merchant history has unanimous category evidence.",
+        "supporting_memory_ids": ["memory-2", "memory-3"],
+    }
+
+    decision = CategorizationDecision(**fields)
+
+    assert decision.accepted_category == "Restaurants"
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            **(
+                fields
+                | {
+                    "accepted_category": None,
+                    "suggested_category": "Restaurants",
+                }
+            )
+        )
+
+
+def test_unresolved_categorization_has_no_category_and_needs_review() -> None:
+    fields = {
+        "transaction_id": "txn-3",
+        "decision_type": DecisionType.UNRESOLVED,
+        "needs_review": True,
+        "confidence": DecisionConfidence.LOW,
+        "reason": "Available evidence is conflicting.",
+    }
+
+    decision = CategorizationDecision(**fields)
+
+    assert decision.accepted_category is None
+    assert decision.suggested_category is None
+    assert decision.proposed_category is None
+
+    with pytest.raises(ValidationError):
+        CategorizationDecision(**(fields | {"accepted_category": "Restaurants"}))
+
+
+def test_recategorization_batch_preserves_order_and_reports_summary_counts() -> None:
+    decision_specs = [
+        {
+            "decision_type": DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
+            "accepted_category": "Restaurants",
+            "needs_review": False,
+        },
+        {
+            "decision_type": DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
+            "suggested_category": "Travel",
+            "needs_review": True,
+        },
+        {
+            "decision_type": DecisionType.UNRESOLVED,
+            "needs_review": True,
+        },
+    ]
+    results = []
+    for position, decision_spec in enumerate(decision_specs):
+        transaction_id = f"txn-{position}"
+        transaction = CanonicalTransaction(
+            transaction_id=transaction_id,
+            direction=TransactionDirection.DEBIT,
+            identity_quality=TransactionIdentityQuality.PARTIAL,
+        )
+        decision = CategorizationDecision(
+            transaction_id=transaction_id,
+            confidence=DecisionConfidence.LOW,
+            reason="Representative batch decision.",
+            **decision_spec,
+        )
+        results.append(
+            RecategorizationResult(
+                position=position,
+                transaction=transaction,
+                decision=decision,
+            )
+        )
+
+    batch = RecategorizationBatch(
+        batch_id="batch-1",
+        status=BatchStatus.COMPLETED,
+        results=results,
+        openai_request_count=1,
+    )
+
+    assert [result.transaction.transaction_id for result in batch.results] == [
+        "txn-0",
+        "txn-1",
+        "txn-2",
+    ]
+    assert batch.total_count == 3
+    assert batch.deterministic_count == 1
+    assert batch.ai_reviewed_count == 1
+    assert batch.unknown_count == 1
+    assert batch.needs_review_count == 2
+    assert batch.approval_required is False
+
+
+def test_recategorization_batch_rejects_a_result_out_of_input_order() -> None:
+    transaction = CanonicalTransaction(
+        transaction_id="txn-0",
+        direction=TransactionDirection.UNKNOWN,
+        identity_quality=TransactionIdentityQuality.INSUFFICIENT,
+    )
+    decision = CategorizationDecision(
+        transaction_id="txn-0",
+        decision_type=DecisionType.UNRESOLVED,
+        needs_review=True,
+        reason="Transaction identity is insufficient.",
+    )
+    misplaced_result = RecategorizationResult(
+        position=1,
+        transaction=transaction,
+        decision=decision,
+    )
+
+    with pytest.raises(ValidationError):
+        RecategorizationBatch(
+            batch_id="batch-2",
+            status=BatchStatus.APPROVAL_REQUIRED,
+            results=[misplaced_result],
+            openai_request_count=0,
+        )
+
+
+def test_recategorization_batch_rejects_duplicate_request_scoped_ids() -> None:
+    transaction = CanonicalTransaction(
+        transaction_id="txn-0",
+        direction=TransactionDirection.UNKNOWN,
+        identity_quality=TransactionIdentityQuality.INSUFFICIENT,
+    )
+    decision = CategorizationDecision(
+        transaction_id="txn-0",
+        decision_type=DecisionType.UNRESOLVED,
+        needs_review=True,
+        reason="Transaction identity is insufficient.",
+    )
+    results = [
+        RecategorizationResult(position=0, transaction=transaction, decision=decision),
+        RecategorizationResult(position=1, transaction=transaction, decision=decision),
+    ]
+
+    with pytest.raises(ValidationError):
+        RecategorizationBatch(
+            batch_id="batch-3",
+            status=BatchStatus.COMPLETED,
+            results=results,
+            openai_request_count=0,
+        )

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from pydantic import ValidationError
 
@@ -18,13 +20,14 @@ def test_source_transaction_preserves_unprocessed_source_values() -> None:
         date="2026-03-24",
         merchant=" ELECTRIFY AMERICA ",
         statement="ELECTRIFY AMERICA 65RESTON VA",
-        amount=-7.0,
+        amount=Decimal("0.1000000000000000001"),
         original_category="Gas",
     )
 
     assert transaction.transaction_id == "txn-1"
     assert transaction.merchant == " ELECTRIFY AMERICA "
     assert transaction.statement == "ELECTRIFY AMERICA 65RESTON VA"
+    assert transaction.amount == Decimal("0.1000000000000000001")
     assert transaction.original_category == "Gas"
 
 
@@ -81,6 +84,26 @@ def test_ai_new_category_proposal_uses_only_proposed_category() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("decision_type", "category_field"),
+    [
+        (DecisionType.AI_SUGGESTION, "suggested_category"),
+        (DecisionType.AI_PROPOSED_NEW_CATEGORY, "proposed_category"),
+    ],
+)
+def test_ai_category_values_must_not_be_blank(
+    decision_type: DecisionType,
+    category_field: str,
+) -> None:
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            decision_id="decision-blank-category",
+            decision_type=decision_type,
+            reason="AI returned an unusable category.",
+            **{category_field: " "},
+        )
+
+
 def test_unresolved_ai_decision_contains_no_category() -> None:
     fields = {
         "decision_id": "decision-3",
@@ -97,6 +120,16 @@ def test_unresolved_ai_decision_contains_no_category() -> None:
     with pytest.raises(ValidationError):
         CategorizationDecision(
             **(fields | {"suggested_category": "Transportation"})
+        )
+
+
+def test_ai_decision_rejects_blank_supporting_memory_id() -> None:
+    with pytest.raises(ValidationError):
+        CategorizationDecision(
+            decision_id="decision-4",
+            decision_type=DecisionType.UNRESOLVED,
+            reason="The available evidence is conflicting.",
+            supporting_memory_ids=["memory-1", " "],
         )
 
 

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -2,293 +2,136 @@ import pytest
 from pydantic import ValidationError
 
 from bookkeeping_app.domain_contracts import (
-    BatchStatus,
     CanonicalTransaction,
     CategorizationDecision,
-    DecisionConfidence,
     DecisionType,
-    RecategorizationBatch,
-    RecategorizationResult,
+    ManualCategorization,
+    SourceTransaction,
     TransactionDirection,
     TransactionIdentityQuality,
 )
 
 
-def test_canonical_transaction_preserves_source_and_normalized_identity() -> None:
-    transaction = CanonicalTransaction(
+def test_source_transaction_preserves_unprocessed_source_values() -> None:
+    transaction = SourceTransaction(
         transaction_id="txn-1",
         date="2026-03-24",
         merchant=" ELECTRIFY AMERICA ",
         statement="ELECTRIFY AMERICA 65RESTON VA",
         amount=-7.0,
         original_category="Gas",
-        normalized_merchant="electrify america",
-        normalized_statement="electrify america 65reston va",
-        direction=TransactionDirection.DEBIT,
-        identity_quality=TransactionIdentityQuality.COMPLETE,
-        fingerprint="sha256:abc123",
     )
 
     assert transaction.transaction_id == "txn-1"
     assert transaction.merchant == " ELECTRIFY AMERICA "
-    assert transaction.normalized_merchant == "electrify america"
-    assert transaction.direction is TransactionDirection.DEBIT
-    assert transaction.identity_quality is TransactionIdentityQuality.COMPLETE
+    assert transaction.statement == "ELECTRIFY AMERICA 65RESTON VA"
+    assert transaction.original_category == "Gas"
 
 
-def test_domain_contracts_reject_blank_identifiers() -> None:
+def test_source_transaction_rejects_blank_identifier() -> None:
     with pytest.raises(ValidationError):
-        CanonicalTransaction(
-            transaction_id=" ",
-            direction=TransactionDirection.UNKNOWN,
-            identity_quality=TransactionIdentityQuality.INSUFFICIENT,
-        )
+        SourceTransaction(transaction_id=" ")
 
+
+def test_manual_categorization_records_a_trusted_user_category() -> None:
+    categorization = ManualCategorization(
+        category="Electric Vehicle Charging",
+        note="Confirmed from charging receipt.",
+    )
+
+    assert categorization.category == "Electric Vehicle Charging"
+    assert categorization.note == "Confirmed from charging receipt."
+
+
+def test_manual_categorization_rejects_blank_category() -> None:
     with pytest.raises(ValidationError):
-        CategorizationDecision(
-            transaction_id=" ",
-            decision_type=DecisionType.UNRESOLVED,
-            needs_review=True,
-            reason="Transaction identity is insufficient.",
-        )
-
-    with pytest.raises(ValidationError):
-        RecategorizationBatch(
-            batch_id=" ",
-            status=BatchStatus.COMPLETED,
-            results=[],
-            openai_request_count=0,
-        )
+        ManualCategorization(category=" ")
 
 
-def test_exact_statement_match_contains_only_an_accepted_category() -> None:
+def test_ai_suggestion_records_category_reason_and_supporting_memory() -> None:
     decision = CategorizationDecision(
-        transaction_id="txn-1",
-        decision_type=DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
-        accepted_category="Electric Vehicle Charging",
-        needs_review=False,
-        confidence=DecisionConfidence.HIGH,
-        reason="Matched a trusted transaction statement.",
+        decision_id="decision-1",
+        decision_type=DecisionType.AI_SUGGESTION,
+        suggested_category="Electric Vehicle Charging",
+        reason="The merchant and statement describe an EV charging session.",
         supporting_memory_ids=["memory-1"],
     )
 
-    assert decision.accepted_category == "Electric Vehicle Charging"
-    assert decision.suggested_category is None
+    assert decision.suggested_category == "Electric Vehicle Charging"
     assert decision.proposed_category is None
-    assert decision.needs_review is False
+    assert decision.supporting_memory_ids == ["memory-1"]
 
 
-@pytest.mark.parametrize(
-    ("decision_type", "category_field"),
-    [
-        (DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY, "suggested_category"),
-        (DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY, "suggested_category"),
-        (DecisionType.AI_PROPOSED_NEW_CATEGORY, "proposed_category"),
-    ],
-)
-def test_every_ai_decision_uses_its_distinct_category_field_and_needs_review(
-    decision_type: DecisionType,
-    category_field: str,
-) -> None:
+def test_ai_new_category_proposal_uses_only_proposed_category() -> None:
     fields = {
-        "transaction_id": "txn-1",
-        "decision_type": decision_type,
-        category_field: "Electric Vehicle Charging",
-        "needs_review": True,
-        "confidence": DecisionConfidence.MEDIUM,
-        "reason": "AI reviewed the available evidence.",
-        "supporting_memory_ids": (
-            ["memory-1"]
-            if decision_type is DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY
-            else []
-        ),
+        "decision_id": "decision-2",
+        "decision_type": DecisionType.AI_PROPOSED_NEW_CATEGORY,
+        "proposed_category": "Electric Vehicle Charging",
+        "reason": "No existing category describes an EV charging session.",
     }
 
     decision = CategorizationDecision(**fields)
 
-    assert getattr(decision, category_field) == "Electric Vehicle Charging"
-    assert decision.accepted_category is None
-
-    with pytest.raises(ValidationError):
-        CategorizationDecision(**(fields | {"needs_review": False}))
-
-
-def test_ai_memory_context_type_agrees_with_supporting_memory() -> None:
-    common_fields = {
-        "transaction_id": "txn-1",
-        "suggested_category": "Electric Vehicle Charging",
-        "needs_review": True,
-        "reason": "AI reviewed the available evidence.",
-    }
+    assert decision.proposed_category == "Electric Vehicle Charging"
+    assert decision.suggested_category is None
 
     with pytest.raises(ValidationError):
         CategorizationDecision(
-            decision_type=DecisionType.AI_SUGGESTION_WITH_RELEVANT_MEMORY,
-            supporting_memory_ids=[],
-            **common_fields,
-        )
-
-    with pytest.raises(ValidationError):
-        CategorizationDecision(
-            decision_type=DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
-            supporting_memory_ids=["memory-1"],
-            **common_fields,
+            **(fields | {"suggested_category": "Transportation"})
         )
 
 
-def test_merchant_consensus_contains_only_an_accepted_category() -> None:
+def test_unresolved_ai_decision_contains_no_category() -> None:
     fields = {
-        "transaction_id": "txn-2",
-        "decision_type": DecisionType.MERCHANT_CONSENSUS,
-        "accepted_category": "Restaurants",
-        "needs_review": False,
-        "confidence": DecisionConfidence.HIGH,
-        "reason": "Trusted merchant history has unanimous category evidence.",
+        "decision_id": "decision-3",
+        "decision_type": DecisionType.UNRESOLVED,
+        "reason": "The available evidence is conflicting.",
         "supporting_memory_ids": ["memory-2", "memory-3"],
     }
 
     decision = CategorizationDecision(**fields)
 
-    assert decision.accepted_category == "Restaurants"
-
-    with pytest.raises(ValidationError):
-        CategorizationDecision(
-            **(
-                fields
-                | {
-                    "accepted_category": None,
-                    "suggested_category": "Restaurants",
-                }
-            )
-        )
-
-
-def test_unresolved_categorization_has_no_category_and_needs_review() -> None:
-    fields = {
-        "transaction_id": "txn-3",
-        "decision_type": DecisionType.UNRESOLVED,
-        "needs_review": True,
-        "confidence": DecisionConfidence.LOW,
-        "reason": "Available evidence is conflicting.",
-    }
-
-    decision = CategorizationDecision(**fields)
-
-    assert decision.accepted_category is None
     assert decision.suggested_category is None
     assert decision.proposed_category is None
 
     with pytest.raises(ValidationError):
-        CategorizationDecision(**(fields | {"accepted_category": "Restaurants"}))
-
-
-def test_recategorization_batch_preserves_order_and_reports_summary_counts() -> None:
-    decision_specs = [
-        {
-            "decision_type": DecisionType.EXACT_STATEMENT_MEMORY_MATCH,
-            "accepted_category": "Restaurants",
-            "needs_review": False,
-        },
-        {
-            "decision_type": DecisionType.AI_SUGGESTION_WITHOUT_RELEVANT_MEMORY,
-            "suggested_category": "Travel",
-            "needs_review": True,
-        },
-        {
-            "decision_type": DecisionType.UNRESOLVED,
-            "needs_review": True,
-        },
-    ]
-    results = []
-    for position, decision_spec in enumerate(decision_specs):
-        transaction_id = f"txn-{position}"
-        transaction = CanonicalTransaction(
-            transaction_id=transaction_id,
-            direction=TransactionDirection.DEBIT,
-            identity_quality=TransactionIdentityQuality.PARTIAL,
-        )
-        decision = CategorizationDecision(
-            transaction_id=transaction_id,
-            confidence=DecisionConfidence.LOW,
-            reason="Representative batch decision.",
-            **decision_spec,
-        )
-        results.append(
-            RecategorizationResult(
-                position=position,
-                transaction=transaction,
-                decision=decision,
-            )
+        CategorizationDecision(
+            **(fields | {"suggested_category": "Transportation"})
         )
 
-    batch = RecategorizationBatch(
-        batch_id="batch-1",
-        status=BatchStatus.COMPLETED,
-        results=results,
-        openai_request_count=1,
+
+def test_canonical_transaction_keeps_source_identity_and_both_categorizations() -> None:
+    source = SourceTransaction(
+        transaction_id="txn-1",
+        merchant=" ELECTRIFY AMERICA ",
+        statement="ELECTRIFY AMERICA 65RESTON VA",
+        amount=-7.0,
+        original_category="Gas",
+    )
+    ai_decision = CategorizationDecision(
+        decision_id="decision-1",
+        decision_type=DecisionType.AI_SUGGESTION,
+        suggested_category="Electric Vehicle Charging",
+        reason="The transaction describes an EV charging session.",
+    )
+    manual_categorization = ManualCategorization(
+        category="Vehicle Charging",
+        note="User corrected the category name.",
     )
 
-    assert [result.transaction.transaction_id for result in batch.results] == [
-        "txn-0",
-        "txn-1",
-        "txn-2",
-    ]
-    assert batch.total_count == 3
-    assert batch.deterministic_count == 1
-    assert batch.ai_reviewed_count == 1
-    assert batch.unknown_count == 1
-    assert batch.needs_review_count == 2
-    assert batch.approval_required is False
-
-
-def test_recategorization_batch_rejects_a_result_out_of_input_order() -> None:
     transaction = CanonicalTransaction(
-        transaction_id="txn-0",
-        direction=TransactionDirection.UNKNOWN,
-        identity_quality=TransactionIdentityQuality.INSUFFICIENT,
-    )
-    decision = CategorizationDecision(
-        transaction_id="txn-0",
-        decision_type=DecisionType.UNRESOLVED,
-        needs_review=True,
-        reason="Transaction identity is insufficient.",
-    )
-    misplaced_result = RecategorizationResult(
-        position=1,
-        transaction=transaction,
-        decision=decision,
+        source=source,
+        normalized_merchant="electrify america",
+        normalized_statement="electrify america 65reston va",
+        direction=TransactionDirection.DEBIT,
+        identity_quality=TransactionIdentityQuality.COMPLETE,
+        fingerprint="sha256:abc123",
+        ai_categorization=ai_decision,
+        manual_categorization=manual_categorization,
     )
 
-    with pytest.raises(ValidationError):
-        RecategorizationBatch(
-            batch_id="batch-2",
-            status=BatchStatus.APPROVAL_REQUIRED,
-            results=[misplaced_result],
-            openai_request_count=0,
-        )
-
-
-def test_recategorization_batch_rejects_duplicate_request_scoped_ids() -> None:
-    transaction = CanonicalTransaction(
-        transaction_id="txn-0",
-        direction=TransactionDirection.UNKNOWN,
-        identity_quality=TransactionIdentityQuality.INSUFFICIENT,
-    )
-    decision = CategorizationDecision(
-        transaction_id="txn-0",
-        decision_type=DecisionType.UNRESOLVED,
-        needs_review=True,
-        reason="Transaction identity is insufficient.",
-    )
-    results = [
-        RecategorizationResult(position=0, transaction=transaction, decision=decision),
-        RecategorizationResult(position=1, transaction=transaction, decision=decision),
-    ]
-
-    with pytest.raises(ValidationError):
-        RecategorizationBatch(
-            batch_id="batch-3",
-            status=BatchStatus.COMPLETED,
-            results=results,
-            openai_request_count=0,
-        )
+    assert transaction.source.merchant == " ELECTRIFY AMERICA "
+    assert transaction.normalized_merchant == "electrify america"
+    assert transaction.fingerprint == "sha256:abc123"
+    assert transaction.ai_categorization == ai_decision
+    assert transaction.manual_categorization == manual_categorization


### PR DESCRIPTION
## Summary

- separate unprocessed SourceTransaction values from processed CanonicalTransaction identity
- preserve financial amounts exactly with Decimal
- retain normalized merchant and statement, direction, identity quality, and optional fingerprint on the canonical model
- attach optional AI CategorizationDecision details and trusted ManualCategorization to canonical transactions
- keep AI outcomes limited to suggestion, proposed new category, and unresolved
- defer deterministic categorization, confidence, needs-review flags, and recategorization batch contracts
- document the revised transaction lifecycle and validation rules

## Testing

- .venv/bin/python -m pytest -q (30 passed)
- .venv/bin/python -m compileall -q bookkeeping_app tests

Closes #17