### PR TITLE
Add user ownership to transaction models

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,20 @@
+# AI Bookkeeping
+
+This context describes the people and financial records managed by the
+bookkeeping application.
+
+## Language
+
+**User**:
+A person with a stable identity inside the bookkeeping application. A User is
+independent of any particular login provider or mutable contact information.
+_Avoid_: Account, customer
+
+**Source Transaction**:
+A transaction preserved as received from an external source before identity and
+categorization processing.
+_Avoid_: Raw transaction
+
+**Canonical Transaction**:
+A processed transaction with normalized identity and categorization state.
+_Avoid_: Clean transaction, normalized transaction

--- a/README.md
+++ b/README.md
@@ -239,13 +239,16 @@ judgment UI development:
 
 ```bash
 python -m scripts.dummy_data \
+  --user-id 550e8400-e29b-41d4-a716-446655440000 \
   --count 24 \
   --seed 42 \
   --output data/dummy_transactions.json
 ```
 
-The same count and seed always produce the same JSON. Use at least eight
-transactions to include every supported manual judgment state. See
+The UUID user ID is required and becomes the dataset owner. Every generated
+source and canonical transaction must match it. The same user ID, count, and
+seed always produce the same JSON. Use at least eight transactions to include
+every supported manual judgment state. See
 [docs/dummy-transaction-data.md](docs/dummy-transaction-data.md) for the dataset
 shape and scenario details.
 

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -1,7 +1,8 @@
-"""Framework-independent transaction and categorization domain contracts."""
+"""Framework-independent user, transaction, and categorization contracts."""
 
 from decimal import Decimal
 from enum import StrEnum
+from uuid import UUID, uuid4
 
 from pydantic import (
     BaseModel,
@@ -11,6 +12,8 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+UserId = UUID
 
 
 def _require_non_blank(value: str, field_name: str) -> str:
@@ -43,11 +46,28 @@ class TransactionIdentityQuality(StrEnum):
     INSUFFICIENT = "insufficient"
 
 
+class User(BaseModel):
+    """A person with a stable identity inside the bookkeeping application."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: UserId = Field(default_factory=uuid4)
+    display_name: str | None = None
+
+    @field_validator("display_name")
+    @classmethod
+    def display_name_must_not_be_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _require_non_blank(value, "display_name").strip()
+
+
 class SourceTransaction(BaseModel):
     """Transaction values preserved as received from a source."""
 
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
+    user_id: UserId
     transaction_id: str
     date: str | None = None
     merchant: str | None = None
@@ -126,6 +146,7 @@ class CanonicalTransaction(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    user_id: UserId
     source: SourceTransaction
     normalized_merchant: str | None = None
     normalized_statement: str | None = None
@@ -134,3 +155,9 @@ class CanonicalTransaction(BaseModel):
     fingerprint: str | None = Field(default=None, min_length=1)
     ai_categorization: CategorizationDecision | None = None
     manual_categorization: ManualCategorization | None = None
+
+    @model_validator(mode="after")
+    def user_id_matches_source(self) -> "CanonicalTransaction":
+        if self.user_id != self.source.user_id:
+            raise ValueError("user_id must match source user_id")
+        return self

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -1,9 +1,19 @@
-# Transaction Domain Contracts
+# Domain Contracts
 
-This reference is for developers implementing transaction ingestion,
-normalization, AI categorization, or manual review. The validated models live in
-`bookkeeping_app/domain_contracts.py` and do not depend on FastAPI or OpenAI SDK
-types.
+This reference is for developers implementing users, transaction ingestion,
+normalization, AI categorization, or manual review. The validated models live
+in `bookkeeping_app/domain_contracts.py` and do not depend on FastAPI or OpenAI
+SDK types.
+
+## User
+
+`User` represents a person inside the bookkeeping application. The application
+generates a UUIDv4 when `user_id` is omitted. An existing UUID may be supplied
+when restoring a user. `display_name` is optional, trimmed when provided, and
+must not be blank.
+
+Authentication identities, email addresses, credentials, status, and
+persistence are intentionally deferred until their workflows are defined.
 
 ## Lifecycle
 
@@ -29,6 +39,7 @@ content.
 
 | Field | Meaning |
 | --- | --- |
+| `user_id` | Required UUID of the user who owns the transaction. |
 | `transaction_id` | Non-blank identifier assigned to the source transaction. |
 | `date` | Date value supplied by the source, if present. |
 | `merchant` | Merchant text supplied by the source, if present. |
@@ -47,6 +58,7 @@ identity plus the latest AI and manual categorization state.
 
 | Field | Meaning |
 | --- | --- |
+| `user_id` | Required owner; must match the embedded source transaction. |
 | `source` | The source transaction from which this record was produced. |
 | `normalized_merchant` | Merchant identity produced by normalization. |
 | `normalized_statement` | Statement identity produced by normalization. |
@@ -59,6 +71,10 @@ identity plus the latest AI and manual categorization state.
 The AI and manual categorizations may coexist. Manual review does not overwrite
 the AI decision, allowing later comparison between the suggestion and the
 category selected by the user.
+
+User IDs are UUIDs assigned to a `User`. `CategorizationDecision` and
+`ManualCategorization` inherit the canonical transaction's owner rather than
+duplicating `user_id`.
 
 ## AI Categorization Decision
 

--- a/docs/dummy-transaction-data.md
+++ b/docs/dummy-transaction-data.md
@@ -7,9 +7,15 @@ OpenAI, read user data, or require Faker.
 ## Python Interface
 
 ```python
+from uuid import UUID
+
 from scripts.dummy_data import generate_dummy_transactions
 
-dataset = generate_dummy_transactions(count=24, seed=42)
+dataset = generate_dummy_transactions(
+    user_id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+    count=24,
+    seed=42,
+)
 ```
 
 `generate_dummy_transactions` returns a validated `DummyTransactionDataset`
@@ -17,17 +23,21 @@ with two arrays:
 
 | Field | Contents |
 | --- | --- |
+| `user_id` | UUID that owns the complete generated dataset. |
 | `source_transactions` | Original transaction-level values before processing. |
 | `canonical_transactions` | Processed records with identity and categorization state. |
 
 The arrays have the requested length and matching records use the same embedded
-`SourceTransaction`. The same `count` and `seed` produce byte-equivalent model
-JSON. A different seed changes transaction content. `count` must be positive.
+`SourceTransaction`. The dataset validates that every source and canonical
+record carries the same `user_id` as its top-level owner. The same `count` and
+`seed` produce byte-equivalent model JSON. A different seed changes transaction
+content. `count` must be positive.
 
 ## Command Line
 
 ```bash
 python -m scripts.dummy_data \
+  --user-id 550e8400-e29b-41d4-a716-446655440000 \
   --count 24 \
   --seed 42 \
   --output data/dummy_transactions.json
@@ -35,6 +45,18 @@ python -m scripts.dummy_data \
 
 The command creates missing parent directories and writes one JSON object that
 can be validated with `DummyTransactionDataset.model_validate_json(...)`.
+`--user-id` is required and must be a UUID; the generator never falls back to
+an implicit user.
+
+Generate fixtures for a second user by changing both the owner and output path:
+
+```bash
+python -m scripts.dummy_data \
+  --user-id 550e8400-e29b-41d4-a716-446655440001 \
+  --count 24 \
+  --seed 99 \
+  --output data/second-user-dummy-transactions.json
+```
 
 ## Manual Judgment States
 

--- a/scripts/dummy_data.py
+++ b/scripts/dummy_data.py
@@ -2,7 +2,7 @@
 
 Run from the repository root::
 
-    python -m scripts.dummy_data --count 24 --seed 42 --output data/dummy_transactions.json
+    python -m scripts.dummy_data --user-id 550e8400-e29b-41d4-a716-446655440000 --count 24 --seed 42 --output data/dummy_transactions.json
 
 The output is one ``DummyTransactionDataset`` JSON object containing paired
 ``source_transactions`` and ``canonical_transactions`` arrays. Each canonical
@@ -13,9 +13,10 @@ direction values. Scenario placement is independent of the seed: every eight
 records cycle through unreviewed, AI suggestion, proposed category, unresolved,
 accepted AI, corrected AI, manual-only, and incomplete-input states.
 
-Call ``generate_dummy_transactions(count=..., seed=...)`` directly when models
-are more useful than a file. Generation is local, performs no filesystem writes,
-and does not call OpenAI; only the command-line adapter writes JSON.
+Call ``generate_dummy_transactions(user_id=..., count=..., seed=...)`` directly
+when models are more useful than a file. Generation is local, performs no
+filesystem writes, and does not call OpenAI; only the command-line adapter
+writes JSON.
 """
 
 import argparse
@@ -26,7 +27,7 @@ from hashlib import sha256
 from pathlib import Path
 from random import Random
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from bookkeeping_app.domain_contracts import (
     CanonicalTransaction,
@@ -36,6 +37,7 @@ from bookkeeping_app.domain_contracts import (
     SourceTransaction,
     TransactionDirection,
     TransactionIdentityQuality,
+    UserId,
 )
 
 MERCHANTS = (
@@ -82,8 +84,16 @@ class DummyTransactionDataset(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    user_id: UserId
     source_transactions: list[SourceTransaction]
     canonical_transactions: list[CanonicalTransaction]
+
+    @model_validator(mode="after")
+    def transactions_belong_to_dataset_user(self) -> "DummyTransactionDataset":
+        transactions = [*self.source_transactions, *self.canonical_transactions]
+        if any(transaction.user_id != self.user_id for transaction in transactions):
+            raise ValueError("all transactions must match dataset user_id")
+        return self
 
 
 def _build_categorizations(
@@ -161,7 +171,12 @@ def _build_categorizations(
     return None, None
 
 
-def generate_dummy_transactions(*, count: int = 50, seed: int = 42) -> DummyTransactionDataset:
+def generate_dummy_transactions(
+    *,
+    user_id: UserId,
+    count: int = 50,
+    seed: int = 42,
+) -> DummyTransactionDataset:
     """Generate a deterministic, validated transaction dataset."""
 
     if count <= 0:
@@ -187,6 +202,7 @@ def generate_dummy_transactions(*, count: int = 50, seed: int = 42) -> DummyTran
         transaction_id = f"txn-{index + 1:04d}"
         transaction_date = date(2026, 1, 1) + timedelta(days=rng.randint(0, 180))
         source = SourceTransaction(
+            user_id=user_id,
             transaction_id=transaction_id,
             date=transaction_date.isoformat(),
             merchant=None if is_incomplete else merchant,
@@ -205,6 +221,7 @@ def generate_dummy_transactions(*, count: int = 50, seed: int = 42) -> DummyTran
             )
             fingerprint = f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
         canonical = CanonicalTransaction(
+            user_id=user_id,
             source=source,
             normalized_merchant=None if is_incomplete else normalized_merchant,
             normalized_statement=None if is_incomplete else statement.lower(),
@@ -226,6 +243,7 @@ def generate_dummy_transactions(*, count: int = 50, seed: int = 42) -> DummyTran
         canonical_transactions.append(canonical)
 
     return DummyTransactionDataset(
+        user_id=user_id,
         source_transactions=source_transactions,
         canonical_transactions=canonical_transactions,
     )
@@ -239,10 +257,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--count", type=int, default=50)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--user-id", type=UserId, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    dataset = generate_dummy_transactions(count=args.count, seed=args.seed)
+    dataset = generate_dummy_transactions(
+        user_id=args.user_id,
+        count=args.count,
+        seed=args.seed,
+    )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(dataset.model_dump_json(indent=2) + "\n", encoding="utf-8")
     return 0

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from uuid import UUID
 
 import pytest
 from pydantic import ValidationError
@@ -11,11 +12,35 @@ from bookkeeping_app.domain_contracts import (
     SourceTransaction,
     TransactionDirection,
     TransactionIdentityQuality,
+    User,
 )
+
+USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+OTHER_USER_ID = UUID("550e8400-e29b-41d4-a716-446655440001")
+
+
+def test_user_gets_a_generated_uuid() -> None:
+    user = User()
+
+    assert isinstance(user.user_id, UUID)
+    assert user.display_name is None
+
+
+def test_user_accepts_an_existing_uuid_and_display_name() -> None:
+    user = User(user_id=USER_ID, display_name="  Wei Liu  ")
+
+    assert user.user_id == USER_ID
+    assert user.display_name == "Wei Liu"
+
+
+def test_user_rejects_blank_display_name() -> None:
+    with pytest.raises(ValidationError):
+        User(display_name=" ")
 
 
 def test_source_transaction_preserves_unprocessed_source_values() -> None:
     transaction = SourceTransaction(
+        user_id=USER_ID,
         transaction_id="txn-1",
         date="2026-03-24",
         merchant=" ELECTRIFY AMERICA ",
@@ -24,6 +49,7 @@ def test_source_transaction_preserves_unprocessed_source_values() -> None:
         original_category="Gas",
     )
 
+    assert transaction.user_id == USER_ID
     assert transaction.transaction_id == "txn-1"
     assert transaction.merchant == " ELECTRIFY AMERICA "
     assert transaction.statement == "ELECTRIFY AMERICA 65RESTON VA"
@@ -33,7 +59,24 @@ def test_source_transaction_preserves_unprocessed_source_values() -> None:
 
 def test_source_transaction_rejects_blank_identifier() -> None:
     with pytest.raises(ValidationError):
-        SourceTransaction(transaction_id=" ")
+        SourceTransaction(user_id=USER_ID, transaction_id=" ")
+
+
+def test_source_transaction_requires_user_id() -> None:
+    with pytest.raises(ValidationError):
+        SourceTransaction(transaction_id="txn-1")
+
+
+@pytest.mark.parametrize("user_id", ["", "user-1", "not-a-uuid"])
+def test_source_transaction_rejects_invalid_user_id(user_id: str) -> None:
+    with pytest.raises(ValidationError):
+        SourceTransaction(user_id=user_id, transaction_id="txn-1")
+
+
+def test_source_transaction_parses_uuid_string() -> None:
+    transaction = SourceTransaction(user_id=str(USER_ID), transaction_id="txn-1")
+
+    assert transaction.user_id == USER_ID
 
 
 def test_manual_categorization_records_a_trusted_user_category() -> None:
@@ -135,6 +178,7 @@ def test_ai_decision_rejects_blank_supporting_memory_id() -> None:
 
 def test_canonical_transaction_keeps_source_identity_and_both_categorizations() -> None:
     source = SourceTransaction(
+        user_id=USER_ID,
         transaction_id="txn-1",
         merchant=" ELECTRIFY AMERICA ",
         statement="ELECTRIFY AMERICA 65RESTON VA",
@@ -153,6 +197,7 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
     )
 
     transaction = CanonicalTransaction(
+        user_id=USER_ID,
         source=source,
         normalized_merchant="electrify america",
         normalized_statement="electrify america 65reston va",
@@ -163,8 +208,21 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
         manual_categorization=manual_categorization,
     )
 
+    assert transaction.user_id == USER_ID
     assert transaction.source.merchant == " ELECTRIFY AMERICA "
     assert transaction.normalized_merchant == "electrify america"
     assert transaction.fingerprint == "sha256:abc123"
     assert transaction.ai_categorization == ai_decision
     assert transaction.manual_categorization == manual_categorization
+
+
+def test_canonical_transaction_rejects_source_owned_by_another_user() -> None:
+    source = SourceTransaction(user_id=USER_ID, transaction_id="txn-1")
+
+    with pytest.raises(ValidationError, match="must match source user_id"):
+        CanonicalTransaction(
+            user_id=OTHER_USER_ID,
+            source=source,
+            direction=TransactionDirection.UNKNOWN,
+            identity_quality=TransactionIdentityQuality.INSUFFICIENT,
+        )

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -2,34 +2,43 @@ import subprocess
 import sys
 from decimal import Decimal
 from pathlib import Path
+from uuid import UUID
 
 import pytest
+from pydantic import ValidationError
 
 from scripts.dummy_data import (
     DummyTransactionDataset,
     generate_dummy_transactions,
 )
-from bookkeeping_app.domain_contracts import DecisionType, TransactionIdentityQuality
+from bookkeeping_app.domain_contracts import (
+    DecisionType,
+    SourceTransaction,
+    TransactionIdentityQuality,
+)
+
+USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
 
 
 def test_dummy_dataset_is_reproducible_for_count_and_seed() -> None:
-    first = generate_dummy_transactions(count=5, seed=42)
-    second = generate_dummy_transactions(count=5, seed=42)
+    first = generate_dummy_transactions(user_id=USER_ID, count=5, seed=42)
+    second = generate_dummy_transactions(user_id=USER_ID, count=5, seed=42)
 
     assert len(first.source_transactions) == 5
     assert len(first.canonical_transactions) == 5
+    assert first.user_id == USER_ID
     assert first.model_dump_json() == second.model_dump_json()
 
 
 def test_dummy_dataset_changes_with_seed() -> None:
-    first = generate_dummy_transactions(count=5, seed=42)
-    second = generate_dummy_transactions(count=5, seed=43)
+    first = generate_dummy_transactions(user_id=USER_ID, count=5, seed=42)
+    second = generate_dummy_transactions(user_id=USER_ID, count=5, seed=43)
 
     assert first.model_dump_json() != second.model_dump_json()
 
 
 def test_dummy_dataset_round_trips_through_json() -> None:
-    dataset = generate_dummy_transactions(count=8, seed=42)
+    dataset = generate_dummy_transactions(user_id=USER_ID, count=8, seed=42)
 
     restored = DummyTransactionDataset.model_validate_json(dataset.model_dump_json())
 
@@ -45,16 +54,35 @@ def test_dummy_dataset_round_trips_through_json() -> None:
     assert all(
         isinstance(source.amount, Decimal) for source in restored.source_transactions
     )
+    assert all(source.user_id == USER_ID for source in restored.source_transactions)
+    assert all(
+        canonical.user_id == USER_ID
+        for canonical in restored.canonical_transactions
+    )
 
 
 @pytest.mark.parametrize("count", [0, -1])
 def test_dummy_dataset_rejects_non_positive_count(count: int) -> None:
     with pytest.raises(ValueError, match="count must be positive"):
-        generate_dummy_transactions(count=count, seed=42)
+        generate_dummy_transactions(user_id=USER_ID, count=count, seed=42)
+
+
+def test_dummy_dataset_rejects_transaction_owned_by_another_user() -> None:
+    other_user_id = UUID("550e8400-e29b-41d4-a716-446655440001")
+
+    with pytest.raises(ValidationError, match="must match dataset user_id"):
+        DummyTransactionDataset(
+            user_id=USER_ID,
+            source_transactions=[
+                SourceTransaction(user_id=other_user_id, transaction_id="txn-1")
+            ],
+            canonical_transactions=[],
+        )
 
 
 def test_dummy_dataset_covers_manual_judgment_ui_states() -> None:
     transactions = generate_dummy_transactions(
+        user_id=USER_ID,
         count=8,
         seed=42,
     ).canonical_transactions
@@ -118,6 +146,8 @@ def test_dummy_data_cli_writes_a_valid_dataset(tmp_path: Path) -> None:
             "scripts.dummy_data",
             "--count",
             "8",
+            "--user-id",
+            str(USER_ID),
             "--seed",
             "123",
             "--output",
@@ -133,3 +163,4 @@ def test_dummy_data_cli_writes_a_valid_dataset(tmp_path: Path) -> None:
     dataset = DummyTransactionDataset.model_validate_json(output_path.read_text())
     assert len(dataset.source_transactions) == 8
     assert len(dataset.canonical_transactions) == 8
+    assert {item.user_id for item in dataset.source_transactions} == {USER_ID}


### PR DESCRIPTION
## Summary

- add a minimal User model with generated UUIDv4 identity
- require matching UUID ownership on source and canonical transactions
- make dummy datasets user-owned and validate all nested transactions
- document the user and transaction ownership vocabulary

## Scope

This is the data-model foundation for #11 and #15. API request identity, categorization-memory isolation, and API refactoring are intentionally deferred to #34 and later ownership work.

## Testing

- `python3 -m py_compile main.py bookkeeping_app/*.py tests/*.py`
- `.venv/bin/python -m pytest -q` — 47 passed

Closes #33
