### PR TITLE
Derive canonical transaction ownership from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ python -m scripts.dummy_data \
 ```
 
 The UUID user ID is required and becomes the dataset owner. Every generated
-source and canonical transaction must match it. The same user ID, count, and
-seed always produce the same JSON. Use at least eight transactions to include
-every supported manual judgment state. See
+source transaction uses it, and canonical transactions inherit ownership from
+their embedded source rather than duplicating the field. The same user ID,
+count, and seed always produce the same JSON. Use at least eight transactions
+to include every supported manual judgment state. See
 [docs/dummy-transaction-data.md](docs/dummy-transaction-data.md) for the dataset
 shape and scenario details.
 

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -146,7 +146,6 @@ class CanonicalTransaction(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    user_id: UserId
     source: SourceTransaction
     normalized_merchant: str | None = None
     normalized_statement: str | None = None
@@ -155,9 +154,3 @@ class CanonicalTransaction(BaseModel):
     fingerprint: str | None = Field(default=None, min_length=1)
     ai_categorization: CategorizationDecision | None = None
     manual_categorization: ManualCategorization | None = None
-
-    @model_validator(mode="after")
-    def user_id_matches_source(self) -> "CanonicalTransaction":
-        if self.user_id != self.source.user_id:
-            raise ValueError("user_id must match source user_id")
-        return self

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -58,7 +58,6 @@ identity plus the latest AI and manual categorization state.
 
 | Field | Meaning |
 | --- | --- |
-| `user_id` | Required owner; must match the embedded source transaction. |
 | `source` | The source transaction from which this record was produced. |
 | `normalized_merchant` | Merchant identity produced by normalization. |
 | `normalized_statement` | Statement identity produced by normalization. |
@@ -72,9 +71,9 @@ The AI and manual categorizations may coexist. Manual review does not overwrite
 the AI decision, allowing later comparison between the suggestion and the
 category selected by the user.
 
-User IDs are UUIDs assigned to a `User`. `CategorizationDecision` and
-`ManualCategorization` inherit the canonical transaction's owner rather than
-duplicating `user_id`.
+User IDs are UUIDs assigned to a `User`. `CanonicalTransaction`,
+`CategorizationDecision`, and `ManualCategorization` inherit ownership from the
+embedded source transaction rather than duplicating `user_id`.
 
 ## AI Categorization Decision
 

--- a/docs/dummy-transaction-data.md
+++ b/docs/dummy-transaction-data.md
@@ -28,10 +28,11 @@ with two arrays:
 | `canonical_transactions` | Processed records with identity and categorization state. |
 
 The arrays have the requested length and matching records use the same embedded
-`SourceTransaction`. The dataset validates that every source and canonical
-record carries the same `user_id` as its top-level owner. The same `count` and
-`seed` produce byte-equivalent model JSON. A different seed changes transaction
-content. `count` must be positive.
+`SourceTransaction`. The dataset validates that every source record, including
+each source embedded in a canonical record, carries the same `user_id` as its
+top-level owner. Canonical records do not duplicate the source owner. The same
+`count` and `seed` produce byte-equivalent model JSON. A different seed changes
+transaction content. `count` must be positive.
 
 ## Command Line
 

--- a/scripts/dummy_data.py
+++ b/scripts/dummy_data.py
@@ -90,8 +90,11 @@ class DummyTransactionDataset(BaseModel):
 
     @model_validator(mode="after")
     def transactions_belong_to_dataset_user(self) -> "DummyTransactionDataset":
-        transactions = [*self.source_transactions, *self.canonical_transactions]
-        if any(transaction.user_id != self.user_id for transaction in transactions):
+        source_transactions = [
+            *self.source_transactions,
+            *(canonical.source for canonical in self.canonical_transactions),
+        ]
+        if any(source.user_id != self.user_id for source in source_transactions):
             raise ValueError("all transactions must match dataset user_id")
         return self
 
@@ -221,7 +224,6 @@ def generate_dummy_transactions(
             )
             fingerprint = f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
         canonical = CanonicalTransaction(
-            user_id=user_id,
             source=source,
             normalized_merchant=None if is_incomplete else normalized_merchant,
             normalized_statement=None if is_incomplete else statement.lower(),

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -16,7 +16,6 @@ from bookkeeping_app.domain_contracts import (
 )
 
 USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
-OTHER_USER_ID = UUID("550e8400-e29b-41d4-a716-446655440001")
 
 
 def test_user_gets_a_generated_uuid() -> None:
@@ -197,7 +196,6 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
     )
 
     transaction = CanonicalTransaction(
-        user_id=USER_ID,
         source=source,
         normalized_merchant="electrify america",
         normalized_statement="electrify america 65reston va",
@@ -208,21 +206,9 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
         manual_categorization=manual_categorization,
     )
 
-    assert transaction.user_id == USER_ID
+    assert transaction.source.user_id == USER_ID
     assert transaction.source.merchant == " ELECTRIFY AMERICA "
     assert transaction.normalized_merchant == "electrify america"
     assert transaction.fingerprint == "sha256:abc123"
     assert transaction.ai_categorization == ai_decision
     assert transaction.manual_categorization == manual_categorization
-
-
-def test_canonical_transaction_rejects_source_owned_by_another_user() -> None:
-    source = SourceTransaction(user_id=USER_ID, transaction_id="txn-1")
-
-    with pytest.raises(ValidationError, match="must match source user_id"):
-        CanonicalTransaction(
-            user_id=OTHER_USER_ID,
-            source=source,
-            direction=TransactionDirection.UNKNOWN,
-            identity_quality=TransactionIdentityQuality.INSUFFICIENT,
-        )

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -56,7 +56,11 @@ def test_dummy_dataset_round_trips_through_json() -> None:
     )
     assert all(source.user_id == USER_ID for source in restored.source_transactions)
     assert all(
-        canonical.user_id == USER_ID
+        canonical.source.user_id == USER_ID
+        for canonical in restored.canonical_transactions
+    )
+    assert all(
+        "user_id" not in canonical.model_dump()
         for canonical in restored.canonical_transactions
     )
 


### PR DESCRIPTION
## Summary

- remove the duplicated `CanonicalTransaction.user_id` field
- derive canonical ownership from the required embedded source transaction
- keep dataset ownership validation against direct and embedded source records
- update dummy-data output, tests, and documentation

## Testing

- `python3 -m py_compile main.py bookkeeping_app/*.py tests/*.py`
- `.venv/bin/python -m pytest -q` — 46 passed

Follow-up to #33.
