### PR TITLE
Add basic GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Compile Python files
+        run: python -m compileall -q main.py bookkeeping_app tests
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -248,6 +248,13 @@ The API runs at `http://127.0.0.1:8000`.
 pytest
 ```
 
+## Continuous Integration
+
+GitHub Actions runs Python compilation and the full test suite for every pull
+request and every push to `master`. The workflow does not require an OpenAI API
+key. Configure the `test` job as a required status check in the repository's
+branch protection settings.
+
 ## Generate Dummy Transactions
 
 Generate deterministic source and canonical transactions for local manual

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -25,7 +26,7 @@ def running_server(tmp_path: Path):
 
     process = subprocess.Popen(
         [
-            str(Path(".venv/bin/python")),
+            sys.executable,
             "-m",
             "uvicorn",
             "main:app",


### PR DESCRIPTION
## Summary
- run compilation and the full pytest suite on pull requests and pushes to master
- use Python 3.14 with pip dependency caching and concurrency cancellation
- make the live integration test portable by launching Uvicorn with `sys.executable`
- document CI and the `test` required status check

## Testing
- `.venv/bin/python -m compileall -q main.py bookkeeping_app tests`
- `.venv/bin/python -m pytest -q` (48 passed)

Closes #37