### PR TITLE
Evolve canonical transaction and memory contracts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,7 @@ A transaction preserved as received from an external source before identity and 
 _Avoid_: Raw transaction
 
 **Canonical Transaction**:
-A processed transaction represented in the application's shared vocabulary while preserving its source values, ownership, and normalized identity. Its identifier is unique within one recategorization request.
+A processed transaction represented in the application's shared vocabulary while preserving its source values, ownership, and normalized identity. Its identifier is globally unique and remains stable throughout the transaction's lifetime.
 _Avoid_: Parsed row, API transaction, clean transaction
 
 **Categorization Decision**:
@@ -52,6 +52,10 @@ _Avoid_: Fraud, transaction anomaly
 **Trusted Categorization**:
 A category confirmed by the user or imported from a source explicitly designated as trustworthy. AI suggestions are not trusted categorizations until confirmed.
 _Avoid_: High-confidence suggestion
+
+**Categorization Memory**:
+The collection of Canonical Transactions that have a Trusted Categorization and may therefore serve as evidence for future Categorization Decisions.
+_Avoid_: Training data, AI memory, categorization-memory item
 
 **False Categorization**:
 An assigned category that differs from the category the user confirms as correct. This is the primary failure the product is designed to minimize.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Focus modules:
 Phase 1 will:
 
 - normalize incoming transactions into one canonical shape
-- assign request-scoped transaction IDs
-- create optional fingerprints for duplicate detection
+- assign globally unique transaction IDs that remain stable after import
+- require deterministic fingerprints for canonical transaction duplicate detection
 - retrieve trusted memory by normalized merchant and transaction direction
 - resolve strong deterministic matches without OpenAI
 - preserve conflicting history for multi-category merchants
@@ -240,9 +240,11 @@ Current rules:
 - memory import and retrieval do not call OpenAI
 - AI suggestions are not added automatically
 
-Phase 1 will add optional transaction fingerprints and duplicate-aware evidence
-counting. A UUID will remain the record identity; the fingerprint will only
-detect repeated imports.
+Phase 1 requires deterministic transaction fingerprints and duplicate-aware
+evidence counting. A globally unique UUID remains the record identity; the
+fingerprint only detects repeated imports. Inputs without enough identity to
+produce a meaningful fingerprint remain Source Transactions and do not become
+Canonical Transactions.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Each item represents one trusted historical decision:
   "statement": "ELECTRIFY AMERICA 65RESTON VA",
   "normalized_merchant": "electrify america",
   "amount": -7.0,
-  "direction": "expense",
+  "direction": "debit",
   "original_category": null,
   "corrected_category": "Electric Vehicle Charging",
   "source": "imported_labeled_history",
@@ -313,7 +313,7 @@ Example response:
     "merchant": "Electrify America",
     "statement": "ELECTRIFY AMERICA 65RESTON VA",
     "amount": -7.0,
-    "direction": "expense",
+    "direction": "debit",
     "original_category": null,
     "category": "Electric Vehicle Charging",
     "notes": "EV charging merchant"

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -43,7 +43,15 @@ class TransactionIdentityQuality(StrEnum):
 
     COMPLETE = "complete"
     PARTIAL = "partial"
-    INSUFFICIENT = "insufficient"
+
+
+class TrustedCategorizationSource(StrEnum):
+    """How a categorization became trusted by the application."""
+
+    IMPORTED_HISTORY = "imported_history"
+    MANUAL_CLASSIFICATION = "manual_classification"
+    CONFIRMED_AI_SUGGESTION = "confirmed_ai_suggestion"
+    CORRECTED_AI_SUGGESTION = "corrected_ai_suggestion"
 
 
 class User(BaseModel):
@@ -68,25 +76,21 @@ class SourceTransaction(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     user_id: UserId
-    transaction_id: str
+    transaction_id: UUID = Field(default_factory=uuid4)
     date: str | None = None
     merchant: str | None = None
     statement: str | None = None
     amount: Decimal | None = None
     original_category: str | None = None
 
-    @field_validator("transaction_id")
-    @classmethod
-    def transaction_id_must_not_be_blank(cls, value: str) -> str:
-        return _require_non_blank(value, "transaction_id")
 
-
-class ManualCategorization(BaseModel):
-    """A category explicitly selected by a user and therefore trusted."""
+class TrustedCategorization(BaseModel):
+    """A category trusted through import or an explicit user decision."""
 
     model_config = ConfigDict(extra="forbid")
 
     category: str
+    source: TrustedCategorizationSource
     note: str | None = None
 
     @field_validator("category")
@@ -153,6 +157,6 @@ class CanonicalTransaction(BaseModel):
     normalized_statement: str | None = None
     direction: TransactionDirection
     identity_quality: TransactionIdentityQuality
-    fingerprint: str | None = Field(default=None, min_length=1)
+    fingerprint: str = Field(min_length=1)
     ai_categorization: CategorizationDecision | None = None
-    manual_categorization: ManualCategorization | None = None
+    trusted_categorization: TrustedCategorization | None = None

--- a/bookkeeping_app/domain_contracts.py
+++ b/bookkeeping_app/domain_contracts.py
@@ -35,7 +35,6 @@ class TransactionDirection(StrEnum):
 
     DEBIT = "debit"
     CREDIT = "credit"
-    UNKNOWN = "unknown"
 
 
 class TransactionIdentityQuality(StrEnum):

--- a/bookkeeping_app/memory.py
+++ b/bookkeeping_app/memory.py
@@ -42,6 +42,8 @@ def build_memory_item(
     statement: str | None = None,
     original_category: str | None = None,
     notes: str | None = None,
+    # Legacy memory-item provenance. TrustedCategorizationSource replaces this
+    # once the memory routes migrate to CanonicalTransaction persistence.
     source: str = "imported_labeled_history",
 ) -> CategorizationMemoryItem:
     cleaned_merchant = sanitize_text(merchant)

--- a/bookkeeping_app/memory.py
+++ b/bookkeeping_app/memory.py
@@ -7,7 +7,7 @@ from io import StringIO
 from pathlib import Path
 
 from bookkeeping_app.config import CATEGORIZATION_MEMORY_PATH
-from bookkeeping_app.domain_contracts import UserId
+from bookkeeping_app.domain_contracts import TransactionDirection, UserId
 from bookkeeping_app.memory_schema import CategorizationMemoryItem
 from bookkeeping_app.parsers import normalize_amount, sanitize_text
 
@@ -26,10 +26,10 @@ def normalize_merchant(value: str | None) -> str | None:
     return collapsed or None
 
 
-def infer_direction(amount: float | None) -> str | None:
+def infer_direction(amount: float | None) -> TransactionDirection | None:
     if amount is None:
         return None
-    return "income" if amount >= 0 else "expense"
+    return TransactionDirection.CREDIT if amount >= 0 else TransactionDirection.DEBIT
 
 
 def build_memory_item(

--- a/bookkeeping_app/memory_schema.py
+++ b/bookkeeping_app/memory_schema.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from bookkeeping_app.domain_contracts import UserId
+from bookkeeping_app.domain_contracts import TransactionDirection, UserId
 
 
 def utc_now_iso() -> str:
@@ -22,7 +22,7 @@ class CategorizationMemoryItem(BaseModel):
     statement: str | None = None
     normalized_merchant: str
     amount: float | None = None
-    direction: str | None = None
+    direction: TransactionDirection | None = None
     original_category: str | None = None
     corrected_category: str
     source: str = "imported_labeled_history"

--- a/bookkeeping_app/memory_schema.py
+++ b/bookkeeping_app/memory_schema.py
@@ -25,7 +25,13 @@ class CategorizationMemoryItem(BaseModel):
     direction: TransactionDirection | None = None
     original_category: str | None = None
     corrected_category: str
-    source: str = "imported_labeled_history"
+    source: str = Field(
+        default="imported_labeled_history",
+        description=(
+            "Legacy memory-item provenance; replaced by "
+            "CanonicalTransaction.trusted_categorization.source"
+        ),
+    )
     notes: str | None = None
     created_at: str = Field(default_factory=utc_now_iso)
     updated_at: str = Field(default_factory=utc_now_iso)

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -24,7 +24,7 @@ SourceTransaction
         v
 CanonicalTransaction
         |-- ai_categorization: CategorizationDecision | None
-        `-- manual_categorization: ManualCategorization | None
+        `-- trusted_categorization: TrustedCategorization | None
 ```
 
 `SourceTransaction` and `CanonicalTransaction` are separate models. If
@@ -40,7 +40,7 @@ content.
 | Field | Meaning |
 | --- | --- |
 | `user_id` | Required UUID of the user who owns the transaction. |
-| `transaction_id` | Non-blank identifier assigned to the source transaction. |
+| `transaction_id` | Globally unique UUID that remains stable for the transaction lifetime. |
 | `date` | Date value supplied by the source, if present. |
 | `merchant` | Merchant text supplied by the source, if present. |
 | `statement` | Statement or description supplied by the source, if present. |
@@ -62,18 +62,22 @@ identity plus the latest AI and manual categorization state.
 | `normalized_merchant` | Merchant identity produced by normalization. |
 | `normalized_statement` | Statement identity produced by normalization. |
 | `direction` | `debit`, `credit`, or `unknown`. |
-| `identity_quality` | `complete`, `partial`, or `insufficient`. |
-| `fingerprint` | Optional stable identity used for duplicate detection. |
+| `identity_quality` | `complete` or `partial`. |
+| `fingerprint` | Required stable identity used for duplicate detection. |
 | `ai_categorization` | Optional AI decision details. |
-| `manual_categorization` | Optional trusted category selected by the user. |
+| `trusted_categorization` | Optional trusted category and the source of that trust. |
 
-The AI and manual categorizations may coexist. Manual review does not overwrite
-the AI decision, allowing later comparison between the suggestion and the
-category selected by the user.
+The AI and trusted categorizations may coexist. A trusted categorization does
+not overwrite the AI decision, allowing later comparison between the suggestion
+and the category accepted by the application.
 
 User IDs are UUIDs assigned to a `User`. `CanonicalTransaction`,
-`CategorizationDecision`, and `ManualCategorization` inherit ownership from the
+`CategorizationDecision`, and `TrustedCategorization` inherit ownership from the
 embedded source transaction rather than duplicating `user_id`.
+
+If the source identity is insufficient to generate a meaningful fingerprint,
+the Source Transaction remains available but no Canonical Transaction is
+constructed.
 
 ## AI Categorization Decision
 
@@ -92,13 +96,14 @@ Each decision has a non-blank `decision_id` and `reason`. It may cite
 
 An AI decision never becomes trusted automatically. If the user accepts the AI
 suggestion, the application records the same category in
-`manual_categorization`.
+`trusted_categorization` with source `confirmed_ai_suggestion`.
 
-## Manual Categorization
+## Trusted Categorization
 
-`ManualCategorization` contains a non-blank category explicitly selected by the
-user and an optional note. Its presence means manual review has occurred; its
-absence means the transaction has not received a manual judgment.
+`TrustedCategorization` contains a non-blank category, an optional note, and the
+source through which trust was established: imported history, manual
+classification, a confirmed AI suggestion, or a corrected AI suggestion. Its
+presence makes the Canonical Transaction eligible for Categorization Memory.
 
 ## Deferred Contracts
 

--- a/docs/domain-contracts.md
+++ b/docs/domain-contracts.md
@@ -61,7 +61,7 @@ identity plus the latest AI and manual categorization state.
 | `source` | The source transaction from which this record was produced. |
 | `normalized_merchant` | Merchant identity produced by normalization. |
 | `normalized_statement` | Statement identity produced by normalization. |
-| `direction` | `debit`, `credit`, or `unknown`. |
+| `direction` | `debit` or `credit`; an amount is required before canonicalization. |
 | `identity_quality` | `complete` or `partial`. |
 | `fingerprint` | Required stable identity used for duplicate detection. |
 | `ai_categorization` | Optional AI decision details. |

--- a/docs/dummy-transaction-data.md
+++ b/docs/dummy-transaction-data.md
@@ -1,8 +1,8 @@
 # Dummy Transaction Data
 
-The deterministic dummy data generator provides paired `SourceTransaction` and
-`CanonicalTransaction` records for local UI development. It does not call
-OpenAI, read user data, or require Faker.
+The deterministic dummy data generator provides `SourceTransaction` records and
+their successfully constructed `CanonicalTransaction` results for local UI
+development. It does not call OpenAI, read user data, or require Faker.
 
 ## Python Interface
 
@@ -27,12 +27,13 @@ with two arrays:
 | `source_transactions` | Original transaction-level values before processing. |
 | `canonical_transactions` | Processed records with identity and categorization state. |
 
-The arrays have the requested length and matching records use the same embedded
-`SourceTransaction`. The dataset validates that every source record, including
-each source embedded in a canonical record, carries the same `user_id` as its
-top-level owner. Canonical records do not duplicate the source owner. The same
-`count` and `seed` produce byte-equivalent model JSON. A different seed changes
-transaction content. `count` must be positive.
+The source array has the requested length. A source without enough identity to
+produce a fingerprint has no canonical counterpart. Matching records use the
+same embedded `SourceTransaction`. The dataset validates that every source
+record, including each source embedded in a canonical record, carries the same
+`user_id` as its top-level owner. Canonical records do not duplicate the source
+owner. The same `count` and `seed` produce byte-equivalent model JSON. A
+different seed changes transaction content. `count` must be positive.
 
 ## Command Line
 
@@ -64,7 +65,7 @@ python -m scripts.dummy_data \
 The generator cycles through eight scenarios in a fixed order. Generate at
 least eight records to include all states in one dataset.
 
-| State | AI categorization | Manual categorization | Identity |
+| State | AI categorization | Trusted categorization | Identity |
 | --- | --- | --- | --- |
 | Unreviewed | None | None | Complete |
 | AI suggestion | Suggested category | None | Complete |
@@ -73,7 +74,7 @@ least eight records to include all states in one dataset.
 | Accepted AI | Suggested category | Same category | Complete |
 | Corrected AI | Suggested category | Different category | Complete |
 | Manual only | None | Selected category | Complete |
-| Incomplete input | None | None | Insufficient; no fingerprint |
+| Incomplete input | None | None | Source retained; no canonical transaction |
 
 The seed controls merchant, amount, direction, and date values. Scenario
 placement is based on record position so UI state coverage remains predictable

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -62,7 +62,7 @@ transaction.
   "merchant": "Electrify America",
   "normalized_merchant": "electrify america",
   "amount": -7.0,
-  "direction": "expense",
+  "direction": "debit",
   "original_category": "Gas",
   "corrected_category": "Electric Vehicle Charging",
   "source": "manual_override",

--- a/docs/memory-store-design.md
+++ b/docs/memory-store-design.md
@@ -10,8 +10,8 @@ The application currently persists categorization memory as a JSON array of
 - legacy memory directions used `income` and `expense`; all transaction models
   now use `credit` and `debit`
 - memory records lack user ownership and canonical transaction identity
-- canonical fingerprints are optional, while the new invariant requires every
-  canonical transaction to have one
+- legacy canonical fingerprints were optional; the domain contract now requires
+  every canonical transaction to have one
 
 The agreed domain direction is that Categorization Memory is not a second kind
 of transaction. It is the collection of Canonical Transactions whose
@@ -59,7 +59,7 @@ categorization is trusted.
 
 ### Trusted categorization
 
-Replace the narrow `ManualCategorization` model with a trusted categorization
+The narrow `ManualCategorization` model is replaced by a trusted categorization
 that records how trust was established.
 
 ```python
@@ -96,7 +96,7 @@ application can later compare a suggestion with the user's final decision.
 
 ### Transaction identity
 
-`transaction_id` should be a globally unique UUID that remains stable for the
+`transaction_id` is a globally unique UUID that remains stable for the
 life of the imported transaction. It identifies a record. The fingerprint is a
 deterministic value derived from normalized transaction facts and detects
 equivalent transactions across repeated imports.
@@ -298,12 +298,12 @@ criteria no longer contradict the design.
 
 ### Step 1: Evolve domain contracts
 
-- Add `TrustedCategorizationSource` and `TrustedCategorization`.
-- Replace `manual_categorization` with `trusted_categorization`.
-- Make `fingerprint` required on Canonical Transaction.
-- Make transaction IDs globally unique and stable.
-- Decide whether `INSUFFICIENT` remains a Source ingestion result or is removed
-  from `TransactionIdentityQuality`.
+- Add `TrustedCategorizationSource` and `TrustedCategorization`. (Complete)
+- Replace `manual_categorization` with `trusted_categorization`. (Complete)
+- Make `fingerprint` required on Canonical Transaction. (Complete)
+- Make transaction IDs globally unique and stable. (Complete)
+- Remove `INSUFFICIENT` from `TransactionIdentityQuality`; insufficient sources
+  do not produce Canonical Transactions. (Complete)
 - Update domain and dummy-data tests.
 
 Exit criteria: invalid Canonical Transactions cannot be constructed, imported
@@ -401,8 +401,8 @@ duplicate count, conflict count, rejected count, and elapsed time.
 
 ## Risks
 
-- Changing request-scoped transaction IDs to persistent IDs affects existing
-  tests and the Phase 1 issue contract.
+- The change from request-scoped transaction IDs to persistent IDs affects the
+  Phase 1 issue contract and downstream integrations.
 - The minimum fingerprint fields may reject transaction sources the current CSV
   parser accepts.
 - Replacing manual categorization terminology affects dummy fixtures and future
@@ -422,9 +422,7 @@ duplicate count, conflict count, rejected count, and elapsed time.
    to construct a Canonical Transaction?
 3. Should authorized category replacement mutate the existing transaction or
    append a revision while marking the old categorization inactive?
-4. Should `TransactionIdentityQuality.INSUFFICIENT` be removed or retained only
-   for a separate ingestion-result model?
-5. Should `supporting_memory_ids` be renamed to
+4. Should `supporting_memory_ids` be renamed to
    `supporting_transaction_ids` after transaction IDs become persistent?
-6. Should the Phase 1 FileMemoryStore support multiple writer processes, or is a
+5. Should the Phase 1 FileMemoryStore support multiple writer processes, or is a
    documented single-writer constraint sufficient?

--- a/docs/memory-store-design.md
+++ b/docs/memory-store-design.md
@@ -1,0 +1,430 @@
+# Memory Store Design and Implementation Plan
+
+## Context
+
+The application currently persists categorization memory as a JSON array of
+`CategorizationMemoryItem` objects. That persistence model duplicates most of
+`CanonicalTransaction` while using incompatible field types and vocabulary:
+
+- memory amounts use `float`; domain amounts use `Decimal`
+- legacy memory directions used `income` and `expense`; all transaction models
+  now use `credit` and `debit`
+- memory records lack user ownership and canonical transaction identity
+- canonical fingerprints are optional, while the new invariant requires every
+  canonical transaction to have one
+
+The agreed domain direction is that Categorization Memory is not a second kind
+of transaction. It is the collection of Canonical Transactions whose
+categorization is trusted.
+
+## Goals
+
+- Use `CanonicalTransaction` as the only normalized transaction model.
+- Represent imported and user-confirmed categories uniformly as trusted
+  categorizations.
+- Require every Canonical Transaction to have a deterministic fingerprint.
+- Introduce a small `MemoryStore` interface that supports file-backed,
+  database-backed, and in-memory adapters.
+- Enforce user isolation, trust, duplicate detection, and conflict handling at
+  the Memory Store seam.
+- Keep retrieval ranking and categorization decisions outside persistence.
+- Preserve AI suggestions independently from trusted categorizations for later
+  review and audit.
+
+## Non-goals
+
+- Selecting a database or ORM.
+- Adding a persistent review queue.
+- Designing deletion, history revision, or rollback workflows.
+- Automatically trusting AI suggestions.
+- Adding generic CRUD methods to the Memory Store.
+- Implementing category-reference validation.
+
+## Constraints and assumptions
+
+- Storage remains file-backed during Phase 1.
+- A database-backed adapter must be possible without changing callers.
+- All financial records are user-owned and all queries are user-scoped.
+- Fingerprints detect duplicate transactions; they are not record identifiers.
+- A Canonical Transaction is constructed only when a meaningful deterministic
+  fingerprint can be generated.
+- A Source Transaction whose identity is insufficient remains available as an
+  ingestion failure or incomplete input; it does not become a Canonical
+  Transaction.
+- The checked-in memory file is currently empty, so no production data migration
+  is needed in the repository. Migration behavior must still fail safely for
+  non-empty legacy files.
+
+## Proposed domain model
+
+### Trusted categorization
+
+Replace the narrow `ManualCategorization` model with a trusted categorization
+that records how trust was established.
+
+```python
+class TrustedCategorizationSource(StrEnum):
+    IMPORTED_HISTORY = "imported_history"
+    MANUAL_CLASSIFICATION = "manual_classification"
+    CONFIRMED_AI_SUGGESTION = "confirmed_ai_suggestion"
+    CORRECTED_AI_SUGGESTION = "corrected_ai_suggestion"
+
+
+class TrustedCategorization(BaseModel):
+    category: str
+    source: TrustedCategorizationSource
+    note: str | None = None
+```
+
+`CanonicalTransaction` retains AI and trusted categorization independently:
+
+```python
+class CanonicalTransaction(BaseModel):
+    source: SourceTransaction
+    normalized_merchant: str | None = None
+    normalized_statement: str | None = None
+    direction: TransactionDirection
+    identity_quality: TransactionIdentityQuality
+    fingerprint: str = Field(min_length=1)
+    ai_categorization: CategorizationDecision | None = None
+    trusted_categorization: TrustedCategorization | None = None
+```
+
+A transaction with only `ai_categorization` is not trusted and cannot be stored
+as categorization memory. AI and trusted categorizations may coexist so the
+application can later compare a suggestion with the user's final decision.
+
+### Transaction identity
+
+`transaction_id` should be a globally unique UUID that remains stable for the
+life of the imported transaction. It identifies a record. The fingerprint is a
+deterministic value derived from normalized transaction facts and detects
+equivalent transactions across repeated imports.
+
+A fingerprint requires:
+
+- `user_id`
+- normalized date
+- normalized amount
+- at least one of normalized merchant or normalized statement
+
+The exact fingerprint serialization must be versioned or otherwise kept stable.
+Missing identity fields must produce an explicit ingestion result instead of a
+random, request-derived, or nullable fingerprint.
+
+## Memory Store interface
+
+```python
+class MemoryStore(Protocol):
+    def record_trusted(
+        self,
+        commands: Sequence[RecordTrustedCommand],
+    ) -> MemoryWriteResult:
+        """Atomically record trusted canonical transactions."""
+
+    def find_relevant(
+        self,
+        query: MemoryQuery,
+    ) -> tuple[CanonicalTransaction, ...]:
+        """Find trusted transactions for one user, merchant, and direction."""
+
+    def list_for_user(
+        self,
+        query: MemoryListQuery,
+    ) -> MemoryPage:
+        """List one user's trusted transactions with cursor pagination."""
+```
+
+### Recording trusted transactions
+
+Conflict behavior belongs to the write command, not to Canonical Transaction:
+
+```python
+class FingerprintConflictPolicy(StrEnum):
+    REJECT = "reject"
+    REPLACE_TRUSTED_CATEGORY = "replace_trusted_category"
+
+
+class RecordTrustedCommand(BaseModel):
+    transaction: CanonicalTransaction
+    conflict_policy: FingerprintConflictPolicy = FingerprintConflictPolicy.REJECT
+    override_reason: str | None = None
+```
+
+The default is always `REJECT`. `REPLACE_TRUSTED_CATEGORY` requires an explicit
+user-authorized workflow and a non-blank reason. AI output cannot request an
+override.
+
+Per-item outcomes are:
+
+```python
+class MemoryWriteStatus(StrEnum):
+    CREATED = "created"
+    DUPLICATE = "duplicate"
+    CONFLICT = "conflict"
+    REPLACED = "replaced"
+    REJECTED = "rejected"
+```
+
+Write rules:
+
+| Condition | Outcome |
+| --- | --- |
+| New user-scoped fingerprint | `CREATED` |
+| Same user, fingerprint, and trusted category | `DUPLICATE` |
+| Same user and fingerprint, different category, default policy | `CONFLICT` |
+| Same conflict with an authorized replacement policy and reason | `REPLACED` |
+| Missing trusted categorization or invalid ownership | `REJECTED` |
+
+The batch is committed atomically. The result reports each command's outcome;
+expected duplicates and conflicts do not become infrastructure exceptions.
+
+### Finding relevant memory
+
+```python
+class MemoryQuery(BaseModel):
+    user_id: UserId
+    normalized_merchant: str
+    direction: TransactionDirection
+```
+
+`find_relevant` performs only persistence-efficient filtering:
+
+- same user
+- same normalized merchant
+- compatible direction
+- trusted categorization present
+
+It does not rank candidates, calculate consensus, assign confidence, or choose a
+category. A shared retrieval module performs fingerprint deduplication, exact
+statement matching, ranking, aggregate category counts, and example limiting so
+all storage adapters produce the same categorization behavior.
+
+### Listing memory
+
+```python
+class MemoryListQuery(BaseModel):
+    user_id: UserId
+    limit: int = Field(default=100, ge=1, le=500)
+    cursor: str | None = None
+
+
+class MemoryPage(BaseModel):
+    transactions: tuple[CanonicalTransaction, ...]
+    next_cursor: str | None = None
+```
+
+The cursor is opaque to callers. No interface method exposes file offsets,
+database primary keys, or full fingerprint sets.
+
+## Data flow
+
+```text
+CSV row
+  -> SourceTransaction
+  -> canonical ingestion and fingerprinting
+  -> CanonicalTransaction
+  -> trusted import or explicit user decision
+  -> CanonicalTransaction.trusted_categorization
+  -> MemoryStore.record_trusted
+
+New CanonicalTransaction
+  -> MemoryStore.find_relevant
+  -> shared Memory Retrieval
+  -> deterministic rules or bounded AI review
+  -> CategorizationDecision
+```
+
+## Adapters
+
+### FileMemoryStore
+
+- Stores complete Canonical Transactions as JSON.
+- Uses a temporary file and atomic replacement for writes.
+- Serializes `Decimal`, UUID, and enums through Pydantic JSON mode.
+- Enforces user-scoped duplicate and conflict rules.
+- Must not silently accept the legacy flat memory schema.
+
+### DatabaseMemoryStore
+
+- Implements the same interface with transactions and indexed queries.
+- Uses a uniqueness constraint compatible with `(user_id, fingerprint)`.
+- Does not require callers to join transaction and memory tables.
+- Its physical schema may be one table or several; that decision is hidden by
+  the adapter.
+
+### InMemoryMemoryStore
+
+- Supports fast contract tests and engine tests.
+- Implements production semantics rather than bypassing validation.
+
+## Alternatives considered
+
+### Separate flat `CategorizationMemoryItem`
+
+Rejected because it duplicates Canonical Transaction fields and has already
+drifted in amount type, direction vocabulary, ownership, and identity behavior.
+
+### Memory record wrapping a separate transaction table
+
+Not required for Phase 1. It introduces an apparent join requirement without a
+current need for independent memory-record lifecycle. A future database adapter
+may normalize its physical schema internally without changing the interface.
+
+### Generic repository CRUD
+
+Rejected because `save`, `update`, `delete`, `find_by_user`, and
+`get_fingerprint_set` expose implementation details or leave trust and conflict
+semantics to callers.
+
+### Boolean `is_forced`
+
+Rejected in favor of an explicit conflict policy. A boolean does not state what
+is being forced and cannot grow safely when more conflict actions are added.
+
+## Rollout and implementation plan
+
+### Step 0: Align specifications
+
+- Update Phase 1 issues #18 and #19 before implementation.
+- Replace optional-fingerprint requirements with the non-null invariant.
+- State that insufficient Source Transactions do not become Canonical
+  Transactions.
+- Remove the requirement for a separate categorization-memory record model.
+- Document the conflict policy and trusted-only Memory Store rule.
+
+Exit criteria: README, domain contracts documentation, and issue acceptance
+criteria no longer contradict the design.
+
+### Step 1: Evolve domain contracts
+
+- Add `TrustedCategorizationSource` and `TrustedCategorization`.
+- Replace `manual_categorization` with `trusted_categorization`.
+- Make `fingerprint` required on Canonical Transaction.
+- Make transaction IDs globally unique and stable.
+- Decide whether `INSUFFICIENT` remains a Source ingestion result or is removed
+  from `TransactionIdentityQuality`.
+- Update domain and dummy-data tests.
+
+Exit criteria: invalid Canonical Transactions cannot be constructed, imported
+history and manual confirmation use one trusted model, and all model tests pass.
+
+### Step 2: Implement canonical ingestion
+
+- Normalize supported CSV aliases into Source Transactions.
+- Normalize merchant, statement, date, amount, and direction.
+- Generate deterministic fingerprints from the agreed minimum identity fields.
+- Return explicit incomplete-ingestion results for insufficient sources.
+- Preserve input ordering and stable transaction IDs.
+
+Exit criteria: the revised acceptance coverage for #18 passes.
+
+### Step 3: Define the Memory Store seam test-first
+
+- Add the protocol, query, command, page, and result contracts.
+- Write reusable Memory Store contract tests.
+- Implement `InMemoryMemoryStore` as the first adapter.
+- Cover user isolation, atomic batches, duplicates, conflicts, authorized
+  replacement, pagination, and relevant lookup.
+
+Exit criteria: all observable Memory Store behavior is captured through its
+public interface.
+
+### Step 4: Implement FileMemoryStore
+
+- Replace flat `CategorizationMemoryItem` persistence with Canonical
+  Transaction persistence.
+- Use atomic file replacement and safe decoding.
+- Add an explicit empty/legacy schema check.
+- Move CSV parsing and canonicalization outside the adapter.
+- Update the memory HTTP routes to receive the store through dependency
+  injection rather than mutating a module-level path.
+
+Exit criteria: the same contract suite passes against in-memory and file-backed
+adapters, and existing live HTTP tests pass with a temporary file.
+
+### Step 5: Add shared memory retrieval
+
+- Build deterministic deduplication and ranking over `find_relevant` results.
+- Preserve conflicting categories.
+- Compute aggregate counts from all distinct relevant transactions.
+- Limit only the detailed examples supplied to AI.
+- Update decisions to reference supporting transaction IDs, or explicitly
+  retain a storage-owned evidence identifier if transaction IDs are not made
+  persistent.
+
+Exit criteria: revised #19 tests cover exact, duplicate, conflicting,
+user-isolated, and absent evidence.
+
+### Step 6: Integrate the Recategorization Engine
+
+- Inject MemoryStore and the shared retrieval module into the engine.
+- Resolve strong deterministic matches before OpenAI.
+- Send only unresolved transactions to the bounded reviewer.
+- Preserve output order and decision provenance.
+
+Exit criteria: Phase 1 engine and public endpoint acceptance tests pass without
+live OpenAI calls.
+
+### Step 7: Prove database compatibility
+
+- Run the Memory Store contract suite against a minimal database adapter or a
+  throwaway relational prototype.
+- Verify uniqueness, transaction atomicity, cursor behavior, and relevant-query
+  indexing.
+- Do not ship a database dependency until the product needs it.
+
+Exit criteria: no interface change is required to support the second adapter.
+
+## Testing and observability
+
+Contract tests must run unchanged against every adapter. Application tests
+should replace the adapter at the Memory Store seam rather than patch global
+file paths.
+
+Required cases:
+
+- reject an untrusted Canonical Transaction
+- isolate two users in one shared store
+- create a new trusted transaction
+- identify idempotent duplicate imports
+- surface category conflicts without overwriting
+- replace only with explicit policy and reason
+- roll back an atomic batch after infrastructure failure
+- retrieve only matching merchant and direction
+- paginate without omissions or duplicates
+- reject corrupt or legacy file payloads explicitly
+
+Log batch-level counts without logging merchants, statements, amounts, notes,
+or categories. Useful fields include operation, user ID, created count,
+duplicate count, conflict count, rejected count, and elapsed time.
+
+## Risks
+
+- Changing request-scoped transaction IDs to persistent IDs affects existing
+  tests and the Phase 1 issue contract.
+- The minimum fingerprint fields may reject transaction sources the current CSV
+  parser accepts.
+- Replacing manual categorization terminology affects dummy fixtures and future
+  UI assumptions.
+- Atomic file replacement is not sufficient for multiple writer processes
+  unless file locking or a single-writer constraint is added.
+- `REPLACE_TRUSTED_CATEGORY` can destroy audit history unless the adapter keeps a
+  revision log or replacement provenance.
+- Cursor semantics can drift across adapters unless contract tests define stable
+  traversal behavior.
+
+## Open questions
+
+1. Should the fingerprint include normalized statement when merchant is already
+   present, or use statement only as a fallback? This changes duplicate identity.
+2. Are date, amount, and merchant-or-statement the final minimum fields required
+   to construct a Canonical Transaction?
+3. Should authorized category replacement mutate the existing transaction or
+   append a revision while marking the old categorization inactive?
+4. Should `TransactionIdentityQuality.INSUFFICIENT` be removed or retained only
+   for a separate ingestion-result model?
+5. Should `supporting_memory_ids` be renamed to
+   `supporting_transaction_ids` after transaction IDs become persistent?
+6. Should the Phase 1 FileMemoryStore support multiple writer processes, or is a
+   documented single-writer constraint sufficient?

--- a/docs/memory-store-design.md
+++ b/docs/memory-store-design.md
@@ -9,6 +9,8 @@ The application currently persists categorization memory as a JSON array of
 - memory amounts use `float`; domain amounts use `Decimal`
 - legacy memory directions used `income` and `expense`; all transaction models
   now use `credit` and `debit`
+- the legacy flat memory `source` string is replaced by the typed
+  `TrustedCategorizationSource` when routes adopt Canonical Transaction storage
 - memory records lack user ownership and canonical transaction identity
 - legacy canonical fingerprints were optional; the domain contract now requires
   every canonical transaction to have one

--- a/scripts/dummy_data.py
+++ b/scripts/dummy_data.py
@@ -4,9 +4,10 @@ Run from the repository root::
 
     python -m scripts.dummy_data --user-id 550e8400-e29b-41d4-a716-446655440000 --count 24 --seed 42 --output data/dummy_transactions.json
 
-The output is one ``DummyTransactionDataset`` JSON object containing paired
-``source_transactions`` and ``canonical_transactions`` arrays. Each canonical
-transaction embeds its corresponding source transaction.
+The output is one ``DummyTransactionDataset`` JSON object containing
+``source_transactions`` and successfully constructed ``canonical_transactions``
+arrays. Each canonical transaction embeds its corresponding source transaction;
+identity-insufficient sources have no canonical counterpart.
 
 The same count and seed always produce the same merchant, amount, date, and
 direction values. Scenario placement is independent of the seed: every eight
@@ -26,6 +27,7 @@ from decimal import Decimal
 from hashlib import sha256
 from pathlib import Path
 from random import Random
+from uuid import uuid5
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -33,10 +35,11 @@ from bookkeeping_app.domain_contracts import (
     CanonicalTransaction,
     CategorizationDecision,
     DecisionType,
-    ManualCategorization,
     SourceTransaction,
     TransactionDirection,
     TransactionIdentityQuality,
+    TrustedCategorization,
+    TrustedCategorizationSource,
     UserId,
 )
 
@@ -80,7 +83,7 @@ MERCHANTS = (
 
 
 class DummyTransactionDataset(BaseModel):
-    """Paired source and canonical transactions generated for development."""
+    """Source transactions and their successful canonical results."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -102,7 +105,7 @@ class DummyTransactionDataset(BaseModel):
 def _build_categorizations(
     index: int,
     suggested_category: str,
-) -> tuple[CategorizationDecision | None, ManualCategorization | None]:
+) -> tuple[CategorizationDecision | None, TrustedCategorization | None]:
     scenario = index % 8
     decision_id = f"decision-{index + 1:04d}"
     memory_ids = [f"memory-{index + 1:04d}"]
@@ -147,8 +150,9 @@ def _build_categorizations(
                 reason="AI matched the merchant to a known category.",
                 supporting_memory_ids=memory_ids,
             ),
-            ManualCategorization(
+            TrustedCategorization(
                 category=suggested_category,
+                source=TrustedCategorizationSource.CONFIRMED_AI_SUGGESTION,
                 note="User accepted the AI suggestion.",
             ),
         )
@@ -161,14 +165,16 @@ def _build_categorizations(
                 reason="AI matched the merchant to a known category.",
                 supporting_memory_ids=memory_ids,
             ),
-            ManualCategorization(
+            TrustedCategorization(
                 category="Business Expense",
+                source=TrustedCategorizationSource.CORRECTED_AI_SUGGESTION,
                 note="User corrected the AI suggestion.",
             ),
         )
     if scenario == 6:
-        return None, ManualCategorization(
+        return None, TrustedCategorization(
             category=suggested_category,
+            source=TrustedCategorizationSource.MANUAL_CLASSIFICATION,
             note="User categorized this transaction without AI assistance.",
         )
     return None, None
@@ -202,7 +208,7 @@ def generate_dummy_transactions(
         amount = Decimal(rng.randint(199, 25_000)) / Decimal("100")
         if rng.choice((True, False)):
             amount = -amount
-        transaction_id = f"txn-{index + 1:04d}"
+        transaction_id = uuid5(user_id, f"dummy:{seed}:{index}")
         transaction_date = date(2026, 1, 1) + timedelta(days=rng.randint(0, 180))
         source = SourceTransaction(
             user_id=user_id,
@@ -213,35 +219,29 @@ def generate_dummy_transactions(
             amount=amount,
             original_category=None if is_incomplete else original_category,
         )
-        ai_categorization, manual_categorization = _build_categorizations(
-            index,
-            suggested_category,
+        source_transactions.append(source)
+        if is_incomplete:
+            continue
+
+        ai_categorization, trusted_categorization = _build_categorizations(
+            index, suggested_category
         )
-        fingerprint = None
-        if not is_incomplete:
-            fingerprint_input = (
-                f"{source.date}|{normalized_merchant}|{statement.lower()}|{amount}"
-            )
-            fingerprint = f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
+        fingerprint_input = f"{user_id}|{source.date}|{normalized_merchant}|{statement.lower()}|{amount}"
+        fingerprint = f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
         canonical = CanonicalTransaction(
             source=source,
-            normalized_merchant=None if is_incomplete else normalized_merchant,
-            normalized_statement=None if is_incomplete else statement.lower(),
+            normalized_merchant=normalized_merchant,
+            normalized_statement=statement.lower(),
             direction=(
                 TransactionDirection.CREDIT
                 if amount >= 0
                 else TransactionDirection.DEBIT
             ),
-            identity_quality=(
-                TransactionIdentityQuality.INSUFFICIENT
-                if is_incomplete
-                else TransactionIdentityQuality.COMPLETE
-            ),
+            identity_quality=TransactionIdentityQuality.COMPLETE,
             fingerprint=fingerprint,
             ai_categorization=ai_categorization,
-            manual_categorization=manual_categorization,
+            trusted_categorization=trusted_categorization,
         )
-        source_transactions.append(source)
         canonical_transactions.append(canonical)
 
     return DummyTransactionDataset(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,7 +231,7 @@ def test_get_categorization_memory_uses_public_field_names(
             "merchant": "Electrify America",
             "statement": "ELECTRIFY AMERICA 65RESTON VA",
             "amount": -7.0,
-            "direction": "expense",
+            "direction": "debit",
             "original_category": None,
             "category": "Electric Vehicle Charging",
             "notes": None,

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -27,6 +27,13 @@ def test_user_gets_a_generated_uuid() -> None:
     assert user.display_name is None
 
 
+def test_transaction_direction_uses_only_debit_and_credit() -> None:
+    assert set(TransactionDirection) == {
+        TransactionDirection.DEBIT,
+        TransactionDirection.CREDIT,
+    }
+
+
 def test_user_accepts_an_existing_uuid_and_display_name() -> None:
     user = User(user_id=USER_ID, display_name="  Wei Liu  ")
 

--- a/tests/test_domain_contracts.py
+++ b/tests/test_domain_contracts.py
@@ -8,14 +8,16 @@ from bookkeeping_app.domain_contracts import (
     CanonicalTransaction,
     CategorizationDecision,
     DecisionType,
-    ManualCategorization,
     SourceTransaction,
     TransactionDirection,
     TransactionIdentityQuality,
+    TrustedCategorization,
+    TrustedCategorizationSource,
     User,
 )
 
 USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+TRANSACTION_ID = UUID("660e8400-e29b-41d4-a716-446655440000")
 
 
 def test_user_gets_a_generated_uuid() -> None:
@@ -40,7 +42,7 @@ def test_user_rejects_blank_display_name() -> None:
 def test_source_transaction_preserves_unprocessed_source_values() -> None:
     transaction = SourceTransaction(
         user_id=USER_ID,
-        transaction_id="txn-1",
+        transaction_id=TRANSACTION_ID,
         date="2026-03-24",
         merchant=" ELECTRIFY AMERICA ",
         statement="ELECTRIFY AMERICA 65RESTON VA",
@@ -49,48 +51,62 @@ def test_source_transaction_preserves_unprocessed_source_values() -> None:
     )
 
     assert transaction.user_id == USER_ID
-    assert transaction.transaction_id == "txn-1"
+    assert transaction.transaction_id == TRANSACTION_ID
     assert transaction.merchant == " ELECTRIFY AMERICA "
     assert transaction.statement == "ELECTRIFY AMERICA 65RESTON VA"
     assert transaction.amount == Decimal("0.1000000000000000001")
     assert transaction.original_category == "Gas"
 
 
-def test_source_transaction_rejects_blank_identifier() -> None:
+def test_source_transaction_generates_identifier_when_omitted() -> None:
+    transaction = SourceTransaction(user_id=USER_ID)
+
+    assert isinstance(transaction.transaction_id, UUID)
+
+
+def test_source_transaction_rejects_invalid_identifier() -> None:
     with pytest.raises(ValidationError):
         SourceTransaction(user_id=USER_ID, transaction_id=" ")
 
 
 def test_source_transaction_requires_user_id() -> None:
     with pytest.raises(ValidationError):
-        SourceTransaction(transaction_id="txn-1")
+        SourceTransaction(transaction_id=TRANSACTION_ID)
 
 
 @pytest.mark.parametrize("user_id", ["", "user-1", "not-a-uuid"])
 def test_source_transaction_rejects_invalid_user_id(user_id: str) -> None:
     with pytest.raises(ValidationError):
-        SourceTransaction(user_id=user_id, transaction_id="txn-1")
+        SourceTransaction(user_id=user_id, transaction_id=TRANSACTION_ID)
 
 
 def test_source_transaction_parses_uuid_string() -> None:
-    transaction = SourceTransaction(user_id=str(USER_ID), transaction_id="txn-1")
+    transaction = SourceTransaction(
+        user_id=str(USER_ID), transaction_id=str(TRANSACTION_ID)
+    )
 
     assert transaction.user_id == USER_ID
+    assert transaction.transaction_id == TRANSACTION_ID
 
 
-def test_manual_categorization_records_a_trusted_user_category() -> None:
-    categorization = ManualCategorization(
+def test_trusted_categorization_records_category_source_and_note() -> None:
+    categorization = TrustedCategorization(
         category="Electric Vehicle Charging",
+        source=TrustedCategorizationSource.MANUAL_CLASSIFICATION,
         note="Confirmed from charging receipt.",
     )
 
     assert categorization.category == "Electric Vehicle Charging"
+    assert categorization.source is TrustedCategorizationSource.MANUAL_CLASSIFICATION
     assert categorization.note == "Confirmed from charging receipt."
 
 
-def test_manual_categorization_rejects_blank_category() -> None:
+def test_trusted_categorization_rejects_blank_category() -> None:
     with pytest.raises(ValidationError):
-        ManualCategorization(category=" ")
+        TrustedCategorization(
+            category=" ",
+            source=TrustedCategorizationSource.MANUAL_CLASSIFICATION,
+        )
 
 
 def test_ai_suggestion_records_category_reason_and_supporting_memory() -> None:
@@ -174,7 +190,7 @@ def test_ai_decision_rejects_blank_supporting_memory_id() -> None:
 def test_canonical_transaction_keeps_source_identity_and_both_categorizations() -> None:
     source = SourceTransaction(
         user_id=USER_ID,
-        transaction_id="txn-1",
+        transaction_id=TRANSACTION_ID,
         merchant=" ELECTRIFY AMERICA ",
         statement="ELECTRIFY AMERICA 65RESTON VA",
         amount=-7.0,
@@ -186,8 +202,9 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
         suggested_category="Electric Vehicle Charging",
         reason="The transaction describes an EV charging session.",
     )
-    manual_categorization = ManualCategorization(
+    trusted_categorization = TrustedCategorization(
         category="Vehicle Charging",
+        source=TrustedCategorizationSource.CORRECTED_AI_SUGGESTION,
         note="User corrected the category name.",
     )
 
@@ -199,7 +216,7 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
         identity_quality=TransactionIdentityQuality.COMPLETE,
         fingerprint="sha256:abc123",
         ai_categorization=ai_decision,
-        manual_categorization=manual_categorization,
+        trusted_categorization=trusted_categorization,
     )
 
     assert transaction.source.user_id == USER_ID
@@ -207,4 +224,15 @@ def test_canonical_transaction_keeps_source_identity_and_both_categorizations() 
     assert transaction.normalized_merchant == "electrify america"
     assert transaction.fingerprint == "sha256:abc123"
     assert transaction.ai_categorization == ai_decision
-    assert transaction.manual_categorization == manual_categorization
+    assert transaction.trusted_categorization == trusted_categorization
+
+
+def test_canonical_transaction_requires_fingerprint() -> None:
+    source = SourceTransaction(user_id=USER_ID, transaction_id=TRANSACTION_ID)
+
+    with pytest.raises(ValidationError):
+        CanonicalTransaction(
+            source=source,
+            direction=TransactionDirection.DEBIT,
+            identity_quality=TransactionIdentityQuality.PARTIAL,
+        )

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -10,7 +10,6 @@ from pydantic import ValidationError
 from bookkeeping_app.domain_contracts import (
     DecisionType,
     SourceTransaction,
-    TransactionIdentityQuality,
 )
 from scripts.dummy_data import (
     DummyTransactionDataset,
@@ -43,13 +42,12 @@ def test_dummy_dataset_round_trips_through_json() -> None:
     restored = DummyTransactionDataset.model_validate_json(dataset.model_dump_json())
 
     assert restored == dataset
+    sources_by_id = {
+        source.transaction_id: source for source in restored.source_transactions
+    }
     assert all(
-        canonical.source == source
-        for source, canonical in zip(
-            restored.source_transactions,
-            restored.canonical_transactions,
-            strict=True,
-        )
+        canonical.source == sources_by_id[canonical.source.transaction_id]
+        for canonical in restored.canonical_transactions
     )
     assert all(
         isinstance(source.amount, Decimal) for source in restored.source_transactions
@@ -77,28 +75,27 @@ def test_dummy_dataset_rejects_transaction_owned_by_another_user() -> None:
     with pytest.raises(ValidationError, match="must match dataset user_id"):
         DummyTransactionDataset(
             user_id=USER_ID,
-            source_transactions=[
-                SourceTransaction(user_id=other_user_id, transaction_id="txn-1")
-            ],
+            source_transactions=[SourceTransaction(user_id=other_user_id)],
             canonical_transactions=[],
         )
 
 
 def test_dummy_dataset_covers_manual_judgment_ui_states() -> None:
-    transactions = generate_dummy_transactions(
+    dataset = generate_dummy_transactions(
         user_id=USER_ID,
         count=8,
         seed=42,
-    ).canonical_transactions
+    )
+    transactions = dataset.canonical_transactions
 
     assert any(
-        item.ai_categorization is None and item.manual_categorization is None
+        item.ai_categorization is None and item.trusted_categorization is None
         for item in transactions
     )
     assert any(
         item.ai_categorization is not None
         and item.ai_categorization.decision_type is DecisionType.AI_SUGGESTION
-        and item.manual_categorization is None
+        and item.trusted_categorization is None
         for item in transactions
     )
     assert any(
@@ -114,30 +111,30 @@ def test_dummy_dataset_covers_manual_judgment_ui_states() -> None:
     )
     assert any(
         item.ai_categorization is not None
-        and item.manual_categorization is not None
+        and item.trusted_categorization is not None
         and item.ai_categorization.suggested_category
-        == item.manual_categorization.category
+        == item.trusted_categorization.category
         for item in transactions
     )
     assert any(
         item.ai_categorization is not None
         and item.ai_categorization.suggested_category is not None
-        and item.manual_categorization is not None
+        and item.trusted_categorization is not None
         and item.ai_categorization.suggested_category
-        != item.manual_categorization.category
+        != item.trusted_categorization.category
         for item in transactions
     )
     assert any(
-        item.ai_categorization is None and item.manual_categorization is not None
+        item.ai_categorization is None and item.trusted_categorization is not None
         for item in transactions
     )
+    assert all(item.fingerprint for item in transactions)
     assert any(
-        item.identity_quality is TransactionIdentityQuality.INSUFFICIENT
-        and item.source.merchant is None
-        and item.source.statement is None
-        and item.fingerprint is None
-        for item in transactions
+        source.merchant is None and source.statement is None
+        for source in dataset.source_transactions
     )
+    assert len(dataset.source_transactions) == 8
+    assert len(dataset.canonical_transactions) == 7
 
 
 def test_dummy_data_cli_writes_a_valid_dataset(tmp_path: Path) -> None:
@@ -166,5 +163,5 @@ def test_dummy_data_cli_writes_a_valid_dataset(tmp_path: Path) -> None:
     assert output_path.exists()
     dataset = DummyTransactionDataset.model_validate_json(output_path.read_text())
     assert len(dataset.source_transactions) == 8
-    assert len(dataset.canonical_transactions) == 8
+    assert len(dataset.canonical_transactions) == 7
     assert {item.user_id for item in dataset.source_transactions} == {USER_ID}

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -20,8 +20,8 @@ def test_normalize_merchant_removes_noise() -> None:
 
 
 def test_infer_direction_uses_amount_sign() -> None:
-    assert infer_direction(-10.0) == "expense"
-    assert infer_direction(25.0) == "income"
+    assert infer_direction(-10.0) == "debit"
+    assert infer_direction(25.0) == "credit"
     assert infer_direction(None) is None
 
 
@@ -39,7 +39,7 @@ def test_build_memory_item_supports_optional_original_category() -> None:
     assert item.corrected_category == "Electric Vehicle Charging"
     assert item.statement == "ELECTRIFY AMERICA 65RESTON VA"
     assert item.normalized_merchant == "electrify america"
-    assert item.direction == "expense"
+    assert item.direction == "debit"
 
 
 def test_load_and_save_categorization_memory_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- define Categorization Memory as trusted Canonical Transactions
- replace ManualCategorization with source-aware TrustedCategorization
- use globally unique UUID transaction IDs and require canonical fingerprints
- keep identity-insufficient inputs as Source Transactions without canonical results
- document the MemoryStore interface, adapters, conflict policy, and rollout plan
- standardize persisted transaction direction on debit/credit

## Validation

- 50 tests passed
- Python compilation passed
- Ruff checks passed
- Ruff formatting check passed
- git diff --check passed

## Tracking

Relates to #15, #18, and #19. This PR evolves the domain contracts and documents the remaining MemoryStore implementation; it does not close the Phase 1 implementation issues.
