### PR TITLE
Add development user identity for local APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=your_openai_api_key_here
+APP_ENV=development
+DEV_USER_ID=8a802680-06be-4815-986b-58b88392acfc

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,11 @@ This context describes the people and financial records managed by the bookkeepi
 A person with a stable identity inside the bookkeeping application. A User is independent of any particular login provider or mutable contact information.
 _Avoid_: Account, customer
 
+**Development User**:
+A synthetic User with a stable identity used for local development and
+multi-user testing. It represents a product persona, not a software developer.
+_Avoid_: Developer User, real user
+
 **Source Transaction**:
 A transaction preserved as received from an external source before identity and categorization processing.
 _Avoid_: Raw transaction

--- a/README.md
+++ b/README.md
@@ -431,6 +431,25 @@ Optional memory path override:
 CATEGORIZATION_MEMORY_PATH=data/categorization_memory.json
 ```
 
+The checked-in development-user catalog lives at
+`config/development_users.json`. Each developer keeps their selected default in
+their ignored local `.env`; `.env.example` selects Wei Liu as an example. Change
+`DEV_USER_ID` locally to use Jia Zhang or another development UUID. Never commit
+the local `.env` file.
+
+In development, user-owned APIs use `DEV_USER_ID` when the request omits the
+temporary `X-User-Id` header, so the usual local request needs no UUID. To test
+as a different user without editing `.env`, override it per request:
+
+```bash
+curl -H "X-User-Id: 0c050ed3-d41b-468c-9c29-e9e6da905c04" \
+  http://127.0.0.1:8000/categorization-memory
+```
+
+The header is a development seam, not production authentication. Outside
+development, requests to user-owned APIs must supply an explicit user ID until
+verified authentication replaces this interface.
+
 ## Run Locally
 
 ```bash

--- a/bookkeeping_app/memory.py
+++ b/bookkeeping_app/memory.py
@@ -7,6 +7,7 @@ from io import StringIO
 from pathlib import Path
 
 from bookkeeping_app.config import CATEGORIZATION_MEMORY_PATH
+from bookkeeping_app.domain_contracts import UserId
 from bookkeeping_app.memory_schema import CategorizationMemoryItem
 from bookkeeping_app.parsers import normalize_amount, sanitize_text
 
@@ -33,6 +34,7 @@ def infer_direction(amount: float | None) -> str | None:
 
 def build_memory_item(
     *,
+    user_id: UserId,
     merchant: str,
     corrected_category: str,
     amount: float | str | None = None,
@@ -55,6 +57,7 @@ def build_memory_item(
     normalized_amount = normalize_amount(amount)
 
     return CategorizationMemoryItem(
+        user_id=user_id,
         date=sanitize_text(date),
         merchant=cleaned_merchant,
         statement=sanitize_text(statement),
@@ -68,7 +71,10 @@ def build_memory_item(
     )
 
 
-def parse_memory_csv(csv_text: str) -> list[CategorizationMemoryItem]:
+def parse_memory_csv(
+    csv_text: str,
+    user_id: UserId,
+) -> list[CategorizationMemoryItem]:
     reader = csv.DictReader(StringIO(csv_text))
     if not reader.fieldnames:
         raise ValueError("CSV file must include a header row")
@@ -92,6 +98,7 @@ def parse_memory_csv(csv_text: str) -> list[CategorizationMemoryItem]:
 
         items.append(
             build_memory_item(
+                user_id=user_id,
                 merchant=merchant,
                 corrected_category=category,
                 amount=find_memory_csv_value(
@@ -122,10 +129,11 @@ def find_memory_csv_value(row: dict[str, str], candidates: list[str]) -> str | N
 
 def import_categorization_memory_csv(
     csv_text: str,
+    user_id: UserId,
     path: Path | None = None,
 ) -> dict[str, int]:
-    imported_items = parse_memory_csv(csv_text)
-    existing_items = load_categorization_memory(path)
+    imported_items = parse_memory_csv(csv_text, user_id)
+    existing_items = _load_all_categorization_memory(path)
     combined_items = existing_items + imported_items
     save_categorization_memory(combined_items, path)
 
@@ -147,6 +155,17 @@ def ensure_memory_file(path: Path | None = None) -> None:
 
 
 def load_categorization_memory(
+    user_id: UserId,
+    path: Path | None = None,
+) -> list[CategorizationMemoryItem]:
+    return [
+        item
+        for item in _load_all_categorization_memory(path)
+        if item.user_id == user_id
+    ]
+
+
+def _load_all_categorization_memory(
     path: Path | None = None,
 ) -> list[CategorizationMemoryItem]:
     path = resolve_memory_path(path)

--- a/bookkeeping_app/memory_schema.py
+++ b/bookkeeping_app/memory_schema.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from bookkeeping_app.domain_contracts import UserId
+
 
 def utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
@@ -13,6 +15,7 @@ def utc_now_iso() -> str:
 class CategorizationMemoryItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    user_id: UserId
     id: str = Field(default_factory=lambda: str(uuid4()))
     date: str | None = None
     merchant: str

--- a/bookkeeping_app/request_identity.py
+++ b/bookkeeping_app/request_identity.py
@@ -1,0 +1,68 @@
+"""Resolve the active user for API requests before authentication exists."""
+
+import json
+import os
+from pathlib import Path
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Header, HTTPException
+from pydantic import ValidationError
+
+from bookkeeping_app.domain_contracts import User, UserId
+
+DEVELOPMENT_USERS_PATH = (
+    Path(__file__).resolve().parents[1] / "config" / "development_users.json"
+)
+
+
+def load_development_users(
+    path: Path = DEVELOPMENT_USERS_PATH,
+) -> dict[UserId, User]:
+    """Load the checked-in catalog keyed by stable user ID."""
+    try:
+        raw_users = json.loads(path.read_text(encoding="utf-8"))
+        users = [User.model_validate(item) for item in raw_users]
+    except (OSError, json.JSONDecodeError, ValidationError, TypeError) as exc:
+        raise RuntimeError(f"Invalid development user catalog: {path}") from exc
+
+    return {user.user_id: user for user in users}
+
+
+def resolve_user_id(explicit_user_id: UserId | None = None) -> UserId:
+    """Prefer an explicit request identity, then use the local dev default."""
+    if explicit_user_id is not None:
+        return explicit_user_id
+
+    if os.getenv("APP_ENV") != "development":
+        raise HTTPException(status_code=401, detail="X-User-Id header is required")
+
+    configured_user_id = os.getenv("DEV_USER_ID")
+    if not configured_user_id:
+        raise HTTPException(
+            status_code=500,
+            detail="DEV_USER_ID must be configured in development",
+        )
+
+    try:
+        user_id = UUID(configured_user_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="DEV_USER_ID must be a valid UUID",
+        ) from exc
+
+    if user_id not in load_development_users():
+        raise HTTPException(
+            status_code=500,
+            detail="DEV_USER_ID must reference config/development_users.json",
+        )
+
+    return user_id
+
+
+def request_user_id(
+    x_user_id: Annotated[UUID | None, Header(alias="X-User-Id")] = None,
+) -> UserId:
+    """FastAPI dependency for the temporary request identity contract."""
+    return resolve_user_id(x_user_id)

--- a/bookkeeping_app/routes/categorization_memory.py
+++ b/bookkeeping_app/routes/categorization_memory.py
@@ -2,16 +2,19 @@
 
 import logging
 from pathlib import Path
+from typing import Annotated
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from fastapi.responses import JSONResponse
 
 from bookkeeping_app.config import CATEGORIZATION_MEMORY_PATH
+from bookkeeping_app.domain_contracts import UserId
 from bookkeeping_app.memory import (
     import_categorization_memory_csv,
     load_categorization_memory,
 )
 from bookkeeping_app.memory_schema import CategorizationMemoryItem
+from bookkeeping_app.request_identity import request_user_id
 from bookkeeping_app.uploads import read_csv_upload
 
 logger = logging.getLogger("bookkeeping_app")
@@ -20,30 +23,39 @@ MEMORY_PATH: Path = CATEGORIZATION_MEMORY_PATH
 
 
 @router.get("")
-def list_categorization_memory() -> list[dict[str, object]]:
-    items = load_categorization_memory(MEMORY_PATH)
+def list_categorization_memory(
+    response: Response,
+    user_id: Annotated[UserId, Depends(request_user_id)],
+) -> list[dict[str, object]]:
+    response.headers["X-User-Id"] = str(user_id)
+    items = load_categorization_memory(user_id, MEMORY_PATH)
     return [serialize_memory_item(item) for item in items]
 
 
 @router.post("")
 async def create_categorization_memory(
+    user_id: Annotated[UserId, Depends(request_user_id)],
     file: UploadFile = File(...),
 ) -> JSONResponse:
     csv_text = await read_csv_upload(file)
 
     try:
-        result = import_categorization_memory_csv(csv_text, MEMORY_PATH)
+        result = import_categorization_memory_csv(csv_text, user_id, MEMORY_PATH)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     logger.info(
-        "Imported categorization memory endpoint=categorization-memory "
+        "Imported categorization memory endpoint=categorization-memory user_id=%s "
         "filename=%s imported=%s skipped=%s",
+        user_id,
         file.filename,
         result["imported"],
         result["skipped"],
     )
-    return JSONResponse(content=result)
+    return JSONResponse(
+        content=result,
+        headers={"X-User-Id": str(user_id)},
+    )
 
 
 def serialize_memory_item(item: CategorizationMemoryItem) -> dict[str, object]:

--- a/bookkeeping_app/routes/transactions.py
+++ b/bookkeeping_app/routes/transactions.py
@@ -1,12 +1,15 @@
 """Transaction collection routes."""
 
 import logging
+from typing import Annotated
 
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import JSONResponse
 
+from bookkeeping_app.domain_contracts import UserId
 from bookkeeping_app.openai_service import review_transaction_categories
 from bookkeeping_app.parsers import parse_csv_transactions
+from bookkeeping_app.request_identity import request_user_id
 from bookkeeping_app.uploads import read_csv_upload
 
 logger = logging.getLogger("bookkeeping_app")
@@ -14,11 +17,16 @@ router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 
 @router.post("")
-async def create_transactions(file: UploadFile = File(...)) -> JSONResponse:
+async def create_transactions(
+    user_id: Annotated[UserId, Depends(request_user_id)],
+    file: UploadFile = File(...),
+) -> JSONResponse:
     csv_text = await read_csv_upload(file)
     transactions = parse_csv_transactions(csv_text)
     logger.info(
-        "Parsed transaction CSV endpoint=transactions filename=%s transactions=%s",
+        "Parsed transaction CSV endpoint=transactions user_id=%s filename=%s "
+        "transactions=%s",
+        user_id,
         file.filename,
         len(transactions),
     )
@@ -28,4 +36,7 @@ async def create_transactions(file: UploadFile = File(...)) -> JSONResponse:
         "Completed category review endpoint=transactions reviewed_transactions=%s",
         len(reviewed_transactions),
     )
-    return JSONResponse(content=reviewed_transactions)
+    return JSONResponse(
+        content=reviewed_transactions,
+        headers={"X-User-Id": str(user_id)},
+    )

--- a/config/development_users.json
+++ b/config/development_users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "user_id": "8a802680-06be-4815-986b-58b88392acfc",
+    "display_name": "Wei Liu"
+  },
+  {
+    "user_id": "0c050ed3-d41b-468c-9c29-e9e6da905c04",
+    "display_name": "Jia Zhang"
+  }
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,13 @@
 from pathlib import Path
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 
 from bookkeeping_app.api import app
 from bookkeeping_app.metrics import metrics
 
-client = TestClient(app)
+TEST_USER_ID = UUID("8a802680-06be-4815-986b-58b88392acfc")
+client = TestClient(app, headers={"X-User-Id": str(TEST_USER_ID)})
 
 
 def test_openapi_exposes_only_the_supported_routes() -> None:
@@ -66,7 +68,72 @@ def test_create_transactions_uses_review_service(monkeypatch) -> None:
     )
 
     assert response.status_code == 200
+    assert response.headers["X-User-Id"] == str(TEST_USER_ID)
     assert response.json()[0]["suggested_category"] == "Coffee"
+
+
+def test_explicit_request_user_overrides_the_client_default(monkeypatch) -> None:
+    jia_user_id = "0c050ed3-d41b-468c-9c29-e9e6da905c04"
+    monkeypatch.setattr(
+        "bookkeeping_app.routes.transactions.review_transaction_categories",
+        lambda transactions: transactions,
+    )
+
+    response = client.post(
+        "/transactions",
+        headers={"X-User-Id": jia_user_id},
+        files={"file": ("transactions.csv", b"merchant\nCoffee\n", "text/csv")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-User-Id"] == jia_user_id
+
+
+def test_development_default_runs_user_api_without_header(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("DEV_USER_ID", str(TEST_USER_ID))
+    monkeypatch.setattr(
+        "bookkeeping_app.routes.transactions.review_transaction_categories",
+        lambda transactions: transactions,
+    )
+    client_without_user_header = TestClient(app)
+
+    response = client_without_user_header.post(
+        "/transactions",
+        files={"file": ("transactions.csv", b"merchant\nCoffee\n", "text/csv")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-User-Id"] == str(TEST_USER_ID)
+
+
+def test_categorization_memory_is_isolated_by_request_user(
+    tmp_path: Path, monkeypatch
+) -> None:
+    memory_path = tmp_path / "categorization_memory.json"
+    jia_user_id = "0c050ed3-d41b-468c-9c29-e9e6da905c04"
+    monkeypatch.setattr(
+        "bookkeeping_app.routes.categorization_memory.MEMORY_PATH",
+        memory_path,
+    )
+
+    client.post(
+        "/categorization-memory",
+        files={"file": ("wei.csv", b"merchant,category\nWei Market,Groceries\n")},
+    )
+    client.post(
+        "/categorization-memory",
+        headers={"X-User-Id": jia_user_id},
+        files={"file": ("jia.csv", b"merchant,category\nJia Cafe,Coffee\n")},
+    )
+
+    wei_response = client.get("/categorization-memory")
+    jia_response = client.get(
+        "/categorization-memory", headers={"X-User-Id": jia_user_id}
+    )
+
+    assert [item["merchant"] for item in wei_response.json()] == ["Wei Market"]
+    assert [item["merchant"] for item in jia_response.json()] == ["Jia Cafe"]
 
 
 def test_admin_openai_usage_endpoint() -> None:

--- a/tests/test_development_users.py
+++ b/tests/test_development_users.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from bookkeeping_app.domain_contracts import User
+from bookkeeping_app.request_identity import resolve_user_id
+
+WEI_USER_ID = UUID("8a802680-06be-4815-986b-58b88392acfc")
+JIA_USER_ID = UUID("0c050ed3-d41b-468c-9c29-e9e6da905c04")
+
+
+def test_development_user_catalog_contains_valid_distinct_users() -> None:
+    catalog_path = Path("config/development_users.json")
+    users = [
+        User.model_validate(item)
+        for item in json.loads(catalog_path.read_text(encoding="utf-8"))
+    ]
+
+    assert [user.display_name for user in users] == ["Wei Liu", "Jia Zhang"]
+    assert len({user.user_id for user in users}) == len(users)
+
+
+def test_explicit_user_id_overrides_development_default(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("DEV_USER_ID", str(WEI_USER_ID))
+
+    assert resolve_user_id(JIA_USER_ID) == JIA_USER_ID
+
+
+def test_development_user_id_is_loaded_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("DEV_USER_ID", str(WEI_USER_ID))
+
+    assert resolve_user_id() == WEI_USER_ID
+
+
+def test_missing_request_identity_is_rejected_outside_development(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("DEV_USER_ID", raising=False)
+
+    with pytest.raises(HTTPException) as error:
+        resolve_user_id()
+
+    assert error.value.status_code == 401

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import httpx
 import pytest
 
+TEST_USER_ID = "8a802680-06be-4815-986b-58b88392acfc"
+
 
 def get_free_port() -> int:
     with socket.socket() as sock:
@@ -68,6 +70,7 @@ def test_memory_endpoints_over_live_server(running_server: str) -> None:
     with csv_path.open("rb") as file_handle:
         import_response = httpx.post(
             f"{running_server}/categorization-memory",
+            headers={"X-User-Id": TEST_USER_ID},
             files={"file": ("short_transaction.csv", file_handle, "text/csv")},
             timeout=10.0,
         )
@@ -75,7 +78,11 @@ def test_memory_endpoints_over_live_server(running_server: str) -> None:
     assert import_response.status_code == 200
     assert import_response.json() == {"imported": 14, "skipped": 0}
 
-    memory_response = httpx.get(f"{running_server}/categorization-memory", timeout=10.0)
+    memory_response = httpx.get(
+        f"{running_server}/categorization-memory",
+        headers={"X-User-Id": TEST_USER_ID},
+        timeout=10.0,
+    )
     assert memory_response.status_code == 200
 
     memory_items = memory_response.json()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from uuid import UUID
 
 from bookkeeping_app.memory import (
     build_memory_item,
@@ -9,6 +10,9 @@ from bookkeeping_app.memory import (
     parse_memory_csv,
     save_categorization_memory,
 )
+
+WEI_USER_ID = UUID("8a802680-06be-4815-986b-58b88392acfc")
+JIA_USER_ID = UUID("0c050ed3-d41b-468c-9c29-e9e6da905c04")
 
 
 def test_normalize_merchant_removes_noise() -> None:
@@ -23,6 +27,7 @@ def test_infer_direction_uses_amount_sign() -> None:
 
 def test_build_memory_item_supports_optional_original_category() -> None:
     item = build_memory_item(
+        user_id=WEI_USER_ID,
         merchant="Electrify America",
         amount="-7.00",
         corrected_category="Electric Vehicle Charging",
@@ -40,6 +45,7 @@ def test_build_memory_item_supports_optional_original_category() -> None:
 def test_load_and_save_categorization_memory_round_trip(tmp_path: Path) -> None:
     memory_path = tmp_path / "categorization_memory.json"
     item = build_memory_item(
+        user_id=WEI_USER_ID,
         merchant="Whole Foods",
         amount=-42.19,
         corrected_category="Groceries",
@@ -47,7 +53,7 @@ def test_load_and_save_categorization_memory_round_trip(tmp_path: Path) -> None:
     )
 
     save_categorization_memory([item], memory_path)
-    loaded = load_categorization_memory(memory_path)
+    loaded = load_categorization_memory(WEI_USER_ID, memory_path)
 
     assert len(loaded) == 1
     assert loaded[0].merchant == "Whole Foods"
@@ -61,7 +67,7 @@ def test_parse_memory_csv_supports_final_category_only() -> None:
         "Electrify America,-7.0,Electric Vehicle Charging,ELECTRIFY AMERICA 65RESTON VA\n"
     )
 
-    items = parse_memory_csv(csv_text)
+    items = parse_memory_csv(csv_text, WEI_USER_ID)
 
     assert len(items) == 1
     assert items[0].merchant == "Electrify America"
@@ -74,8 +80,8 @@ def test_import_categorization_memory_csv_appends_to_store(tmp_path: Path) -> No
     memory_path = tmp_path / "categorization_memory.json"
     csv_text = "merchant,amount,category\nWhole Foods,-42.19,Groceries\n"
 
-    result = import_categorization_memory_csv(csv_text, memory_path)
-    loaded = load_categorization_memory(memory_path)
+    result = import_categorization_memory_csv(csv_text, WEI_USER_ID, memory_path)
+    loaded = load_categorization_memory(WEI_USER_ID, memory_path)
 
     assert result == {"imported": 1, "skipped": 0}
     assert len(loaded) == 1
@@ -88,8 +94,29 @@ def test_parse_memory_csv_accepts_corrected_category_column() -> None:
         "Whole Foods,-42.19,Groceries,WHOLEFDS SAN JOSE\n"
     )
 
-    items = parse_memory_csv(csv_text)
+    items = parse_memory_csv(csv_text, WEI_USER_ID)
 
     assert len(items) == 1
     assert items[0].corrected_category == "Groceries"
     assert items[0].statement == "WHOLEFDS SAN JOSE"
+
+
+def test_memory_store_filters_users_and_preserves_shared_file(tmp_path: Path) -> None:
+    memory_path = tmp_path / "categorization_memory.json"
+
+    import_categorization_memory_csv(
+        "merchant,category\nWei Market,Groceries\n",
+        WEI_USER_ID,
+        memory_path,
+    )
+    import_categorization_memory_csv(
+        "merchant,category\nJia Cafe,Coffee\n",
+        JIA_USER_ID,
+        memory_path,
+    )
+
+    wei_items = load_categorization_memory(WEI_USER_ID, memory_path)
+    jia_items = load_categorization_memory(JIA_USER_ID, memory_path)
+
+    assert [item.merchant for item in wei_items] == ["Wei Market"]
+    assert [item.merchant for item in jia_items] == ["Jia Cafe"]


### PR DESCRIPTION
## Summary
- add stable checked-in Development Users for Wei Liu and Jia Zhang
- resolve user-owned API requests from explicit `X-User-Id` or the local `DEV_USER_ID` fallback
- reject missing request identity outside development and echo the resolved user ID
- persist categorization-memory ownership and isolate Wei/Jia operations in one shared JSON store
- document local `.env` setup and the temporary development-header boundary

## Testing
- `ruff check main.py bookkeeping_app scripts tests`
- `ruff format --check main.py bookkeeping_app scripts tests`
- `.venv/bin/python -m compileall -q main.py bookkeeping_app tests`
- `.venv/bin/python -m pytest -q` (55 passed)

Closes #47
Part of #11