### PR TITLE
Add canonical transaction ingestion with normalization and fingerprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv/
 __pycache__/
 *.pyc
+data/raw_statements/

--- a/bookkeeping_app/ingestion.py
+++ b/bookkeeping_app/ingestion.py
@@ -1,0 +1,92 @@
+"""Converts parsed transaction rows into canonical transactions."""
+
+from decimal import Decimal
+from hashlib import sha256
+from typing import Any
+
+from bookkeeping_app.domain_contracts import (
+    CanonicalTransaction,
+    SourceTransaction,
+    TransactionDirection,
+    TransactionIdentityQuality,
+    UserId,
+)
+from bookkeeping_app.normalization import normalize_merchant, normalize_statement
+
+
+def _identity_quality(
+    *,
+    normalized_merchant: str | None,
+    normalized_statement: str | None,
+    amount: Decimal | None,
+) -> TransactionIdentityQuality:
+    if not normalized_merchant:
+        return TransactionIdentityQuality.INSUFFICIENT
+
+    if not normalized_statement or amount is None:
+        return TransactionIdentityQuality.PARTIAL
+
+    return TransactionIdentityQuality.COMPLETE
+
+
+def _build_fingerprint(
+    *,
+    date: str | None,
+    normalized_merchant: str | None,
+    normalized_statement: str | None,
+    amount: Decimal | None,
+) -> str | None:
+    if not normalized_merchant or not normalized_statement or amount is None:
+        return None
+
+    fingerprint_input = f"{date}|{normalized_merchant}|{normalized_statement}|{amount}"
+    return f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
+
+
+def build_canonical_transactions(
+    rows: list[dict[str, Any]],
+    *,
+    user_id: UserId,
+) -> list[CanonicalTransaction]:
+    canonical_transactions: list[CanonicalTransaction] = []
+
+    for index, row in enumerate(rows):
+        amount = row.get("amount")
+        decimal_amount = Decimal(str(amount)) if amount is not None else None
+        source = SourceTransaction(
+            user_id=user_id,
+            transaction_id=f"txn-{index + 1}",
+            date=row.get("date"),
+            merchant=row.get("merchant"),
+            statement=row.get("statement"),
+            amount=decimal_amount,
+            original_category=row.get("category"),
+        )
+        normalized_merchant = normalize_merchant(source.merchant)
+        normalized_statement = normalize_statement(source.statement)
+
+        canonical_transactions.append(
+            CanonicalTransaction(
+                source=source,
+                normalized_merchant=normalized_merchant,
+                normalized_statement=normalized_statement,
+                direction=(
+                    TransactionDirection.CREDIT
+                    if amount is not None and amount >= 0
+                    else TransactionDirection.DEBIT
+                ),
+                identity_quality=_identity_quality(
+                    normalized_merchant=normalized_merchant,
+                    normalized_statement=normalized_statement,
+                    amount=decimal_amount,
+                ),
+                fingerprint=_build_fingerprint(
+                    date=source.date,
+                    normalized_merchant=normalized_merchant,
+                    normalized_statement=normalized_statement,
+                    amount=decimal_amount,
+                ),
+            )
+        )
+
+    return canonical_transactions

--- a/bookkeeping_app/ingestion.py
+++ b/bookkeeping_app/ingestion.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 from hashlib import sha256
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict
+
 from bookkeeping_app.domain_contracts import (
     CanonicalTransaction,
     SourceTransaction,
@@ -11,35 +13,35 @@ from bookkeeping_app.domain_contracts import (
     TransactionIdentityQuality,
     UserId,
 )
-from bookkeeping_app.normalization import normalize_merchant, normalize_statement
+from bookkeeping_app.normalization import normalize_merchant
+
+
+class IngestionResult(BaseModel):
+    """The outcome of converting parsed rows into canonical transactions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_transactions: list[CanonicalTransaction]
+    incomplete_sources: list[SourceTransaction]
 
 
 def _identity_quality(
     *,
-    normalized_merchant: str | None,
-    normalized_statement: str | None,
+    date: str | None,
     amount: Decimal | None,
 ) -> TransactionIdentityQuality:
-    if not normalized_merchant:
-        return TransactionIdentityQuality.INSUFFICIENT
-
-    if not normalized_statement or amount is None:
+    if date is None or amount is None:
         return TransactionIdentityQuality.PARTIAL
-
     return TransactionIdentityQuality.COMPLETE
 
 
 def _build_fingerprint(
     *,
     date: str | None,
-    normalized_merchant: str | None,
-    normalized_statement: str | None,
+    normalized_merchant: str,
     amount: Decimal | None,
-) -> str | None:
-    if not normalized_merchant or not normalized_statement or amount is None:
-        return None
-
-    fingerprint_input = f"{date}|{normalized_merchant}|{normalized_statement}|{amount}"
+) -> str:
+    fingerprint_input = f"{date}|{normalized_merchant}|{amount}"
     return f"sha256:{sha256(fingerprint_input.encode()).hexdigest()}"
 
 
@@ -47,46 +49,55 @@ def build_canonical_transactions(
     rows: list[dict[str, Any]],
     *,
     user_id: UserId,
-) -> list[CanonicalTransaction]:
+) -> IngestionResult:
     canonical_transactions: list[CanonicalTransaction] = []
+    incomplete_sources: list[SourceTransaction] = []
 
-    for index, row in enumerate(rows):
+    for row in rows:
         amount = row.get("amount")
         decimal_amount = Decimal(str(amount)) if amount is not None else None
+        merchant = row.get("merchant")
         source = SourceTransaction(
             user_id=user_id,
-            transaction_id=f"txn-{index + 1}",
             date=row.get("date"),
-            merchant=row.get("merchant"),
-            statement=row.get("statement"),
+            merchant=merchant,
+            # Bridge until #54 (drop the separate statement field) is
+            # decided: keep statement in sync with merchant so existing
+            # downstream readers (e.g. the categorization-memory route)
+            # don't silently see a null value.
+            statement=merchant,
             amount=decimal_amount,
             original_category=row.get("category"),
         )
         normalized_merchant = normalize_merchant(source.merchant)
-        normalized_statement = normalize_statement(source.statement)
+
+        if not normalized_merchant:
+            incomplete_sources.append(source)
+            continue
 
         canonical_transactions.append(
             CanonicalTransaction(
                 source=source,
                 normalized_merchant=normalized_merchant,
-                normalized_statement=normalized_statement,
+                normalized_statement=normalized_merchant,
                 direction=(
                     TransactionDirection.CREDIT
                     if amount is not None and amount >= 0
                     else TransactionDirection.DEBIT
                 ),
                 identity_quality=_identity_quality(
-                    normalized_merchant=normalized_merchant,
-                    normalized_statement=normalized_statement,
+                    date=source.date,
                     amount=decimal_amount,
                 ),
                 fingerprint=_build_fingerprint(
                     date=source.date,
                     normalized_merchant=normalized_merchant,
-                    normalized_statement=normalized_statement,
                     amount=decimal_amount,
                 ),
             )
         )
 
-    return canonical_transactions
+    return IngestionResult(
+        canonical_transactions=canonical_transactions,
+        incomplete_sources=incomplete_sources,
+    )

--- a/bookkeeping_app/normalization.py
+++ b/bookkeeping_app/normalization.py
@@ -1,0 +1,27 @@
+"""Normalization helpers shared between source and canonical transactions."""
+
+import re
+
+from bookkeeping_app.parsers import sanitize_text
+
+MULTISPACE_PATTERN = re.compile(r"\s+")
+PUNCTUATION_PATTERN = re.compile(r"[^a-z0-9\s]")
+
+
+def _normalize_text(value: str | None) -> str | None:
+    cleaned = sanitize_text(value)
+    if cleaned is None:
+        return None
+
+    lowered = cleaned.lower()
+    without_punctuation = PUNCTUATION_PATTERN.sub(" ", lowered)
+    collapsed = MULTISPACE_PATTERN.sub(" ", without_punctuation).strip()
+    return collapsed or None
+
+
+def normalize_merchant(value: str | None) -> str | None:
+    return _normalize_text(value)
+
+
+def normalize_statement(value: str | None) -> str | None:
+    return _normalize_text(value)

--- a/bookkeeping_app/normalization.py
+++ b/bookkeeping_app/normalization.py
@@ -8,7 +8,7 @@ MULTISPACE_PATTERN = re.compile(r"\s+")
 PUNCTUATION_PATTERN = re.compile(r"[^a-z0-9\s]")
 
 
-def _normalize_text(value: str | None) -> str | None:
+def normalize_merchant(value: str | None) -> str | None:
     cleaned = sanitize_text(value)
     if cleaned is None:
         return None
@@ -17,11 +17,3 @@ def _normalize_text(value: str | None) -> str | None:
     without_punctuation = PUNCTUATION_PATTERN.sub(" ", lowered)
     collapsed = MULTISPACE_PATTERN.sub(" ", without_punctuation).strip()
     return collapsed or None
-
-
-def normalize_merchant(value: str | None) -> str | None:
-    return _normalize_text(value)
-
-
-def normalize_statement(value: str | None) -> str | None:
-    return _normalize_text(value)

--- a/bookkeeping_app/parsers.py
+++ b/bookkeeping_app/parsers.py
@@ -127,6 +127,7 @@ def parse_csv_transactions(csv_text: str) -> list[dict[str, Any]]:
                 "merchant": find_csv_value(
                     row, ["merchant", "description", "payee", "name"]
                 ),
+                "statement": find_csv_value(row, ["original statement", "statement"]),
                 "category": find_csv_value(row, ["category"]),
             }
         )

--- a/bookkeeping_app/parsers.py
+++ b/bookkeeping_app/parsers.py
@@ -119,10 +119,13 @@ def parse_csv_transactions(csv_text: str) -> list[dict[str, Any]]:
         transactions.append(
             {
                 "date": find_csv_value(
-                    row, ["date", "transaction date", "posted date"]
+                    row,
+                    ["date", "transaction date", "posted date", "date of transaction"],
                 ),
                 "amount": normalize_amount(
-                    find_csv_value(row, ["amount", "transaction amount", "value"])
+                    find_csv_value(
+                        row, ["amount", "transaction amount", "value", "$ amount"]
+                    )
                 ),
                 "merchant": find_csv_value(
                     row,
@@ -133,6 +136,7 @@ def parse_csv_transactions(csv_text: str) -> list[dict[str, Any]]:
                         "name",
                         "original statement",
                         "statement",
+                        "merchant name or transaction description",
                     ],
                 ),
                 "category": find_csv_value(row, ["category"]),

--- a/bookkeeping_app/parsers.py
+++ b/bookkeeping_app/parsers.py
@@ -125,9 +125,16 @@ def parse_csv_transactions(csv_text: str) -> list[dict[str, Any]]:
                     find_csv_value(row, ["amount", "transaction amount", "value"])
                 ),
                 "merchant": find_csv_value(
-                    row, ["merchant", "description", "payee", "name"]
+                    row,
+                    [
+                        "merchant",
+                        "description",
+                        "payee",
+                        "name",
+                        "original statement",
+                        "statement",
+                    ],
                 ),
-                "statement": find_csv_value(row, ["original statement", "statement"]),
                 "category": find_csv_value(row, ["category"]),
             }
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,7 @@ def test_create_transactions_uses_review_service(monkeypatch) -> None:
                 "date": "2026-03-01",
                 "amount": -12.5,
                 "merchant": "Starbucks",
+                "statement": None,
                 "category": "Coffee",
             }
         ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,7 +45,6 @@ def test_create_transactions_uses_review_service(monkeypatch) -> None:
                 "date": "2026-03-01",
                 "amount": -12.5,
                 "merchant": "Starbucks",
-                "statement": None,
                 "category": "Coffee",
             }
         ]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,117 @@
+from decimal import Decimal
+from uuid import UUID
+
+from bookkeeping_app.domain_contracts import (
+    TransactionDirection,
+    TransactionIdentityQuality,
+)
+from bookkeeping_app.ingestion import build_canonical_transactions
+
+USER_ID = UUID("550e8400-e29b-41d4-a716-446655440000")
+
+
+def test_build_canonical_transactions_maps_a_complete_row() -> None:
+    rows = [
+        {
+            "date": "2026-03-02",
+            "merchant": "Whole Foods",
+            "statement": "WHOLEFDS SAN JOSE",
+            "amount": -42.19,
+            "category": "Groceries",
+        }
+    ]
+
+    transactions = build_canonical_transactions(rows, user_id=USER_ID)
+
+    assert len(transactions) == 1
+    canonical = transactions[0]
+    assert canonical.source.user_id == USER_ID
+    assert canonical.source.transaction_id
+    assert canonical.source.merchant == "Whole Foods"
+    assert canonical.source.statement == "WHOLEFDS SAN JOSE"
+    assert canonical.source.original_category == "Groceries"
+    assert canonical.source.amount == Decimal("-42.19")
+    assert canonical.normalized_merchant == "whole foods"
+    assert canonical.normalized_statement == "wholefds san jose"
+    assert canonical.direction == TransactionDirection.DEBIT
+    assert canonical.identity_quality == TransactionIdentityQuality.COMPLETE
+
+
+def test_build_canonical_transactions_preserves_order_and_assigns_unique_ids() -> None:
+    rows = [
+        {"merchant": "Whole Foods", "statement": "WHOLEFDS", "amount": -10, "date": None, "category": None},
+        {"merchant": "Starbucks", "statement": "STARBUCKS", "amount": -5, "date": None, "category": None},
+        {"merchant": "Costco", "statement": "COSTCO", "amount": -100, "date": None, "category": None},
+    ]
+
+    transactions = build_canonical_transactions(rows, user_id=USER_ID)
+
+    assert [t.normalized_merchant for t in transactions] == [
+        "whole foods",
+        "starbucks",
+        "costco",
+    ]
+    ids = [t.source.transaction_id for t in transactions]
+    assert len(ids) == len(set(ids))
+
+
+def test_build_canonical_transactions_fingerprint_is_deterministic() -> None:
+    row = {
+        "date": "2026-03-02",
+        "merchant": "Whole Foods",
+        "statement": "WHOLEFDS SAN JOSE",
+        "amount": -42.19,
+        "category": "Groceries",
+    }
+
+    first = build_canonical_transactions([row], user_id=USER_ID)[0]
+    second = build_canonical_transactions([row], user_id=USER_ID)[0]
+
+    assert first.fingerprint is not None
+    assert first.fingerprint == second.fingerprint
+
+
+def test_build_canonical_transactions_fingerprint_distinguishes_different_transactions() -> None:
+    base_row = {
+        "date": "2026-03-02",
+        "merchant": "Whole Foods",
+        "statement": "WHOLEFDS SAN JOSE",
+        "amount": -42.19,
+        "category": "Groceries",
+    }
+    different_amount_row = {**base_row, "amount": -99.99}
+
+    base = build_canonical_transactions([base_row], user_id=USER_ID)[0]
+    different = build_canonical_transactions([different_amount_row], user_id=USER_ID)[0]
+
+    assert base.fingerprint != different.fingerprint
+
+
+def test_build_canonical_transactions_marks_missing_merchant_insufficient() -> None:
+    row = {
+        "date": "2026-03-02",
+        "merchant": None,
+        "statement": "UNKNOWN CHARGE",
+        "amount": -10.0,
+        "category": None,
+    }
+
+    canonical = build_canonical_transactions([row], user_id=USER_ID)[0]
+
+    assert canonical.identity_quality == TransactionIdentityQuality.INSUFFICIENT
+    assert canonical.fingerprint is None
+
+
+def test_build_canonical_transactions_marks_missing_statement_partial() -> None:
+    row = {
+        "date": "2026-03-02",
+        "merchant": "Whole Foods",
+        "statement": None,
+        "amount": -10.0,
+        "category": None,
+    }
+
+    canonical = build_canonical_transactions([row], user_id=USER_ID)[0]
+
+    assert canonical.identity_quality == TransactionIdentityQuality.PARTIAL
+    assert canonical.fingerprint is None

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -15,59 +15,52 @@ def test_build_canonical_transactions_maps_a_complete_row() -> None:
         {
             "date": "2026-03-02",
             "merchant": "Whole Foods",
-            "statement": "WHOLEFDS SAN JOSE",
             "amount": -42.19,
             "category": "Groceries",
         }
     ]
 
-    transactions = build_canonical_transactions(rows, user_id=USER_ID)
+    result = build_canonical_transactions(rows, user_id=USER_ID)
 
-    assert len(transactions) == 1
-    canonical = transactions[0]
+    assert result.incomplete_sources == []
+    assert len(result.canonical_transactions) == 1
+    canonical = result.canonical_transactions[0]
     assert canonical.source.user_id == USER_ID
-    assert canonical.source.transaction_id
     assert canonical.source.merchant == "Whole Foods"
-    assert canonical.source.statement == "WHOLEFDS SAN JOSE"
     assert canonical.source.original_category == "Groceries"
     assert canonical.source.amount == Decimal("-42.19")
     assert canonical.normalized_merchant == "whole foods"
-    assert canonical.normalized_statement == "wholefds san jose"
     assert canonical.direction == TransactionDirection.DEBIT
     assert canonical.identity_quality == TransactionIdentityQuality.COMPLETE
 
 
-def test_build_canonical_transactions_preserves_order_and_assigns_unique_ids() -> None:
+def test_build_canonical_transactions_preserves_order() -> None:
     rows = [
-        {"merchant": "Whole Foods", "statement": "WHOLEFDS", "amount": -10, "date": None, "category": None},
-        {"merchant": "Starbucks", "statement": "STARBUCKS", "amount": -5, "date": None, "category": None},
-        {"merchant": "Costco", "statement": "COSTCO", "amount": -100, "date": None, "category": None},
+        {"merchant": "Whole Foods", "amount": -10, "date": None, "category": None},
+        {"merchant": "Starbucks", "amount": -5, "date": None, "category": None},
+        {"merchant": "Costco", "amount": -100, "date": None, "category": None},
     ]
 
-    transactions = build_canonical_transactions(rows, user_id=USER_ID)
+    result = build_canonical_transactions(rows, user_id=USER_ID)
 
-    assert [t.normalized_merchant for t in transactions] == [
+    assert [t.normalized_merchant for t in result.canonical_transactions] == [
         "whole foods",
         "starbucks",
         "costco",
     ]
-    ids = [t.source.transaction_id for t in transactions]
-    assert len(ids) == len(set(ids))
 
 
 def test_build_canonical_transactions_fingerprint_is_deterministic() -> None:
     row = {
         "date": "2026-03-02",
         "merchant": "Whole Foods",
-        "statement": "WHOLEFDS SAN JOSE",
         "amount": -42.19,
         "category": "Groceries",
     }
 
-    first = build_canonical_transactions([row], user_id=USER_ID)[0]
-    second = build_canonical_transactions([row], user_id=USER_ID)[0]
+    first = build_canonical_transactions([row], user_id=USER_ID).canonical_transactions[0]
+    second = build_canonical_transactions([row], user_id=USER_ID).canonical_transactions[0]
 
-    assert first.fingerprint is not None
     assert first.fingerprint == second.fingerprint
 
 
@@ -75,43 +68,57 @@ def test_build_canonical_transactions_fingerprint_distinguishes_different_transa
     base_row = {
         "date": "2026-03-02",
         "merchant": "Whole Foods",
-        "statement": "WHOLEFDS SAN JOSE",
         "amount": -42.19,
         "category": "Groceries",
     }
     different_amount_row = {**base_row, "amount": -99.99}
 
-    base = build_canonical_transactions([base_row], user_id=USER_ID)[0]
-    different = build_canonical_transactions([different_amount_row], user_id=USER_ID)[0]
+    base = build_canonical_transactions([base_row], user_id=USER_ID).canonical_transactions[0]
+    different = build_canonical_transactions(
+        [different_amount_row], user_id=USER_ID
+    ).canonical_transactions[0]
 
     assert base.fingerprint != different.fingerprint
 
 
-def test_build_canonical_transactions_marks_missing_merchant_insufficient() -> None:
+def test_build_canonical_transactions_marks_missing_merchant_as_incomplete() -> None:
     row = {
         "date": "2026-03-02",
         "merchant": None,
-        "statement": "UNKNOWN CHARGE",
         "amount": -10.0,
         "category": None,
     }
 
-    canonical = build_canonical_transactions([row], user_id=USER_ID)[0]
+    result = build_canonical_transactions([row], user_id=USER_ID)
 
-    assert canonical.identity_quality == TransactionIdentityQuality.INSUFFICIENT
-    assert canonical.fingerprint is None
+    assert result.canonical_transactions == []
+    assert len(result.incomplete_sources) == 1
+    assert result.incomplete_sources[0].merchant is None
 
 
-def test_build_canonical_transactions_marks_missing_statement_partial() -> None:
+def test_build_canonical_transactions_marks_missing_date_or_amount_as_partial() -> None:
+    row = {
+        "date": None,
+        "merchant": "Whole Foods",
+        "amount": -10.0,
+        "category": None,
+    }
+
+    canonical = build_canonical_transactions([row], user_id=USER_ID).canonical_transactions[0]
+
+    assert canonical.identity_quality == TransactionIdentityQuality.PARTIAL
+    assert canonical.fingerprint
+
+
+def test_build_canonical_transactions_bridges_statement_from_merchant() -> None:
     row = {
         "date": "2026-03-02",
         "merchant": "Whole Foods",
-        "statement": None,
-        "amount": -10.0,
-        "category": None,
+        "amount": -42.19,
+        "category": "Groceries",
     }
 
-    canonical = build_canonical_transactions([row], user_id=USER_ID)[0]
+    canonical = build_canonical_transactions([row], user_id=USER_ID).canonical_transactions[0]
 
-    assert canonical.identity_quality == TransactionIdentityQuality.PARTIAL
-    assert canonical.fingerprint is None
+    assert canonical.source.statement == "Whole Foods"
+    assert canonical.normalized_statement == "whole foods"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -34,6 +34,19 @@ def test_build_canonical_transactions_maps_a_complete_row() -> None:
     assert canonical.identity_quality == TransactionIdentityQuality.COMPLETE
 
 
+def test_build_canonical_transactions_marks_positive_amount_as_credit() -> None:
+    row = {
+        "date": "2026-03-02",
+        "merchant": "Employer Payroll",
+        "amount": 1500.00,
+        "category": None,
+    }
+
+    canonical = build_canonical_transactions([row], user_id=USER_ID).canonical_transactions[0]
+
+    assert canonical.direction == TransactionDirection.CREDIT
+
+
 def test_build_canonical_transactions_preserves_order() -> None:
     rows = [
         {"merchant": "Whole Foods", "amount": -10, "date": None, "category": None},
@@ -48,6 +61,19 @@ def test_build_canonical_transactions_preserves_order() -> None:
         "starbucks",
         "costco",
     ]
+
+
+def test_build_canonical_transactions_assigns_unique_ids_within_a_batch() -> None:
+    rows = [
+        {"merchant": "Whole Foods", "amount": -10, "date": "2026-03-02", "category": None},
+        {"merchant": "Whole Foods", "amount": -10, "date": "2026-03-02", "category": None},
+        {"merchant": "Whole Foods", "amount": -10, "date": "2026-03-02", "category": None},
+    ]
+
+    result = build_canonical_transactions(rows, user_id=USER_ID)
+
+    transaction_ids = [t.source.transaction_id for t in result.canonical_transactions]
+    assert len(set(transaction_ids)) == len(transaction_ids)
 
 
 def test_build_canonical_transactions_fingerprint_is_deterministic() -> None:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,12 @@
+from bookkeeping_app.normalization import normalize_merchant, normalize_statement
+
+
+def test_normalize_merchant_removes_noise() -> None:
+    assert normalize_merchant("  AMZN Mktp US*AB12C  ") == "amzn mktp us ab12c"
+
+
+def test_normalize_statement_removes_noise() -> None:
+    assert (
+        normalize_statement("STARBUCKS  STORE #1234!!")
+        == "starbucks store 1234"
+    )

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,12 +1,5 @@
-from bookkeeping_app.normalization import normalize_merchant, normalize_statement
+from bookkeeping_app.normalization import normalize_merchant
 
 
 def test_normalize_merchant_removes_noise() -> None:
     assert normalize_merchant("  AMZN Mktp US*AB12C  ") == "amzn mktp us ab12c"
-
-
-def test_normalize_statement_removes_noise() -> None:
-    assert (
-        normalize_statement("STARBUCKS  STORE #1234!!")
-        == "starbucks store 1234"
-    )

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -3,3 +3,15 @@ from bookkeeping_app.normalization import normalize_merchant
 
 def test_normalize_merchant_removes_noise() -> None:
     assert normalize_merchant("  AMZN Mktp US*AB12C  ") == "amzn mktp us ab12c"
+
+
+def test_normalize_merchant_returns_none_for_none_input() -> None:
+    assert normalize_merchant(None) is None
+
+
+def test_normalize_merchant_returns_none_for_blank_input() -> None:
+    assert normalize_merchant("   ") is None
+
+
+def test_normalize_merchant_returns_none_for_punctuation_only_input() -> None:
+    assert normalize_merchant("***---###") is None

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -23,7 +23,27 @@ def test_parse_csv_transactions_normalizes_common_columns() -> None:
             "date": "2026-03-02",
             "amount": 1234.5,
             "merchant": "Amazon",
+            "statement": None,
             "category": "Shopping",
+        }
+    ]
+
+
+def test_parse_csv_transactions_captures_statement_column() -> None:
+    csv_text = (
+        "date,merchant,statement,amount,category\n"
+        "2026-03-02,Whole Foods,WHOLEFDS SAN JOSE,-42.19,Groceries\n"
+    )
+
+    transactions = parse_csv_transactions(csv_text)
+
+    assert transactions == [
+        {
+            "date": "2026-03-02",
+            "amount": -42.19,
+            "merchant": "Whole Foods",
+            "statement": "WHOLEFDS SAN JOSE",
+            "category": "Groceries",
         }
     ]
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -23,16 +23,15 @@ def test_parse_csv_transactions_normalizes_common_columns() -> None:
             "date": "2026-03-02",
             "amount": 1234.5,
             "merchant": "Amazon",
-            "statement": None,
             "category": "Shopping",
         }
     ]
 
 
-def test_parse_csv_transactions_captures_statement_column() -> None:
+def test_parse_csv_transactions_treats_statement_column_as_merchant() -> None:
     csv_text = (
-        "date,merchant,statement,amount,category\n"
-        "2026-03-02,Whole Foods,WHOLEFDS SAN JOSE,-42.19,Groceries\n"
+        "date,statement,amount,category\n"
+        "2026-03-02,WHOLEFDS SAN JOSE,-42.19,Groceries\n"
     )
 
     transactions = parse_csv_transactions(csv_text)
@@ -41,8 +40,7 @@ def test_parse_csv_transactions_captures_statement_column() -> None:
         {
             "date": "2026-03-02",
             "amount": -42.19,
-            "merchant": "Whole Foods",
-            "statement": "WHOLEFDS SAN JOSE",
+            "merchant": "WHOLEFDS SAN JOSE",
             "category": "Groceries",
         }
     ]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -46,6 +46,24 @@ def test_parse_csv_transactions_treats_statement_column_as_merchant() -> None:
     ]
 
 
+def test_parse_csv_transactions_supports_credit_card_export_headers() -> None:
+    csv_text = (
+        "Date of Transaction,Merchant Name or Transaction Description,$ Amount\n"
+        "06/15,TARGET T-2581 SAN JOSE CA,-27.51\n"
+    )
+
+    transactions = parse_csv_transactions(csv_text)
+
+    assert transactions == [
+        {
+            "date": "06/15",
+            "amount": -27.51,
+            "merchant": "TARGET T-2581 SAN JOSE CA",
+            "category": None,
+        }
+    ]
+
+
 def test_parse_transactions_normalizes_amount_and_fields() -> None:
     raw_text = '[{"date":"2026-03-01","amount":"-12.50","merchant":" Starbucks ","category":" Coffee "}]'
 


### PR DESCRIPTION
Closes #18. Related: #54 (proposes removing the separate statement field).

## Summary

Implements canonical transaction ingestion, rebased onto the current
memory-store design. Adopts a single-field approach (merchant only,
no separate statement field) per #54.

- `bookkeeping_app/normalization.py`: `normalize_merchant()` (moved out
  of the old `memory.py`, which no longer exists on master)
- `bookkeeping_app/ingestion.py`: `build_canonical_transactions(rows, *, user_id) -> IngestionResult`
  - `merchant` is the only field required to produce a `CanonicalTransaction`
    at all (matches master's existing rule: insufficient sources don't
    become canonical transactions, and `fingerprint` is required/non-null)
  - rows missing merchant are returned as `incomplete_sources`
    (`SourceTransaction` only, not canonicalized) so nothing is silently
    dropped
  - `identity_quality`: `COMPLETE` when merchant + date + amount are all
    present, `PARTIAL` when merchant is present but date or amount isn't
  - fingerprint is deterministic, built from date + amount + normalized
    merchant
- `parsers.py`: CSV column aliases for "statement"/"original statement"
  now feed the single `merchant` field instead of a separate one

## Test plan
- [x] `pytest` — 74 passed
- [x] `ruff check` — clean